### PR TITLE
fix: update markdown-lint workflow

### DIFF
--- a/.github/workflows/_markdown-lint.yml
+++ b/.github/workflows/_markdown-lint.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: read
 jobs:
   markdown-lint:
-    uses: ./.github/workflows/commitmsg-conform.yml
+    uses: ./.github/workflows/markdown-lint.yml


### PR DESCRIPTION
- updates the config to point to the right workflow