### PR TITLE
chore: bump checkout version

### DIFF
--- a/.github/workflows/chart-lint-validate.yml
+++ b/.github/workflows/chart-lint-validate.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/commitmsg-conform.yml
+++ b/.github/workflows/commitmsg-conform.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - id: lint
         env:

--- a/.github/workflows/node-ci-workflow.yml
+++ b/.github/workflows/node-ci-workflow.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/terraform-lint-validate.yml
+++ b/.github/workflows/terraform-lint-validate.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check Terraform Formatting
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Check Terraform Formatting
         uses: dflook/terraform-fmt-check@v2
@@ -28,7 +28,7 @@ jobs:
     needs: fmt-check
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Validate Terraform Configuration
         uses: dflook/terraform-validate@v2

--- a/.github/workflows/terraform-tag-and-release.yml
+++ b/.github/workflows/terraform-tag-and-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Configure Git
         run: |

--- a/.github/workflows/terraform-tag.yml
+++ b/.github/workflows/terraform-tag.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Configure Git
         run: |

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Run yamllint
         uses: karancode/yamllint-github-action@v2.1.0


### PR DESCRIPTION
updates to latest v7 version