### PR TITLE
chore: bump helm/chart-testing-action version

### DIFF
--- a/.github/workflows/chart-lint-validate.yml
+++ b/.github/workflows/chart-lint-validate.yml
@@ -62,7 +62,7 @@ jobs:
           check-latest: true
 
       - name: Set up Chart-Testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f #v2.8.0
 
       - name: Run Chart-Testing (list-changed)
         id: list-changed


### PR DESCRIPTION
updates to use latest stable version