### PR TITLE
chore: update trivy checks

### DIFF
--- a/.github/workflows/docker-image-validate.yml
+++ b/.github/workflows/docker-image-validate.yml
@@ -43,6 +43,11 @@ on:
         type: boolean
         required: false
         default: false
+      trivy-vuln-type:
+        description: Comma-separated vulnerability types for Trivy (os, library)
+        type: string
+        required: false
+        default: "os,library"
 
 permissions:
   contents: read
@@ -87,3 +92,4 @@ jobs:
           severity: ${{ inputs.trivy-severity }}
           exit-code: ${{ inputs.trivy-exit-code }}
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          vuln-type: ${{ inputs.trivy-vuln-type }}

--- a/.github/workflows/python-image-pr-checks.yml
+++ b/.github/workflows/python-image-pr-checks.yml
@@ -60,6 +60,11 @@ on:
         type: boolean
         required: false
         default: true
+      trivy-vuln-type:
+        description: Comma-separated vulnerability types for Trivy (os, library)
+        type: string
+        required: false
+        default: "os,library"
 
 permissions:
   contents: read
@@ -91,3 +96,4 @@ jobs:
       dockerfile: ${{ inputs.dockerfile }}
       context: ${{ inputs.docker-context }}
       platforms: ${{ inputs.docker-platforms }}
+      trivy-vuln-type: ${{ inputs.trivy-vuln-type }}


### PR DESCRIPTION
adds trivy-vuln-type support