### PR TITLE
feat(node-ci-workflow): add typecheck, coverage, and audit inputs

### DIFF
--- a/.github/workflows/node-ci-workflow.yml
+++ b/.github/workflows/node-ci-workflow.yml
@@ -6,8 +6,23 @@ on:
       node-version:
         type: string
         required: false
-        default: '23.5.0'
+        default: '20'
         description: The Node.js version to use for the CI workflow.
+      typecheck:
+        type: boolean
+        required: false
+        default: false
+        description: Run npm run typecheck before tests.
+      coverage:
+        type: boolean
+        required: false
+        default: false
+        description: Pass --coverage flag to npm test.
+      audit:
+        type: boolean
+        required: false
+        default: false
+        description: Run npm audit --audit-level=high after build.
 
 jobs:
   build:
@@ -18,15 +33,24 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --no-audit --no-fund
+
+      - name: Typecheck
+        if: ${{ inputs.typecheck }}
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test${{ inputs.coverage && ' -- --coverage' || '' }}
 
       - name: Build project
         run: npm run build
 
-      - name: Run tests
-        run: npm test
+      - name: Security audit
+        if: ${{ inputs.audit }}
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary

- Adds `typecheck`, `coverage`, and `audit` boolean inputs to `node-ci-workflow.yml` (all default `false` for backward compat)
- Adds `cache: npm` to the setup-node step
- Switches `npm install` → `npm ci --no-audit --no-fund`
- Changes default `node-version` from `23.5.0` to `20` (LTS)
- Reorders steps: install → typecheck → test → build → audit

Closes #98

## Test plan

- [ ] Merge this PR
- [ ] Update `actionsforge/actions-monitor` `ci.yml` to call this reusable with `typecheck: true`, `coverage: true`, `audit: true`, `node-version: '20'`
