### PR TITLE
chore: pin floating actions and optimize reusable workflows

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -40,7 +40,7 @@ jobs:
       issues: write
     steps:
       - name: 'Auto-assign issue'
-        uses: pozil/auto-assign-issue@v4
+        uses: pozil/auto-assign-issue@af6beea6bdf1e8eb373f061c5bc168681fc6d011 #v4.0.1
         with:
           assignees: ${{ inputs.assignees }}
           numOfAssignee: ${{ inputs.numOfAssignee }}

--- a/.github/workflows/chart-lint-validate.yml
+++ b/.github/workflows/chart-lint-validate.yml
@@ -50,8 +50,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve target branch
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.target_branch }}" ]]; then
+            echo "branch=${{ inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 #v5.0.1
         with:
           version: ${{ inputs.helm_version || 'latest' }}
 
@@ -69,7 +80,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch ${{ steps.target.outputs.branch }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -80,7 +91,7 @@ jobs:
         working-directory: ${{ inputs.chart_dirs }}
         run: |
           set -euo pipefail
-          ct lint --target-branch ${{ github.event.repository.default_branch }}
+          ct lint --target-branch ${{ steps.target.outputs.branch }}
 
       - name: Create Kind cluster
         if: ${{ steps.list-changed.outputs.changed == 'true' && (github.event_name == 'pull_request' || inputs.run_install != false) }}
@@ -92,4 +103,4 @@ jobs:
         working-directory: ${{ inputs.chart_dirs }}
         run: |
           set -euo pipefail
-          ct install --target-branch ${{ github.event.repository.default_branch }}
+          ct install --target-branch ${{ steps.target.outputs.branch }}

--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -33,19 +33,21 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 #v5.0.1
         with:
           version: latest
 
       - name: Add Helm Repositories
         id: add-repos
         shell: bash
+        env:
+          CHARTS_DIR: ${{ inputs.charts_dir }}
         run: |
           set -euo pipefail
           REPOS_FILE=$(mktemp)
           
           # Extract repository URLs from Chart.yaml files
-          find charts -name "Chart.yaml" -type f | while IFS= read -r chart_file; do
+          find "${CHARTS_DIR}" -name "Chart.yaml" -type f | while IFS= read -r chart_file; do
             if grep -q "dependencies:" "$chart_file"; then
               grep -A 50 "dependencies:" "$chart_file" | grep "repository:" | \
                 sed -E 's/.*repository:[[:space:]]*["'\'']?([^"'\'']+)["'\'']?[[:space:]]*$/\1/' | \
@@ -66,7 +68,7 @@ jobs:
             done < <(sort -u "${REPOS_FILE}")
             echo "repos_added=${REPOS_ADDED}" >> "$GITHUB_OUTPUT"
           else
-            echo "No dependencies found in charts, skipping repository addition"
+            echo "No dependencies found in ${CHARTS_DIR}, skipping repository addition"
             echo "repos_added=false" >> "$GITHUB_OUTPUT"
           fi
           
@@ -78,9 +80,11 @@ jobs:
 
       - name: Build and Unpack Chart Dependencies
         shell: bash
+        env:
+          CHARTS_DIR: ${{ inputs.charts_dir }}
         run: |
           set -euo pipefail
-          for dir in charts/*/; do
+          for dir in "${CHARTS_DIR}"/*/; do
             [ ! -d "$dir" ] && continue
             echo "Processing chart: ${dir}"
             
@@ -115,7 +119,7 @@ jobs:
                 rm -f "${tgz}"
               done
               cd - > /dev/null
-              echo "✅ Dependencies unpacked successfully"
+              echo "Dependencies unpacked successfully"
             else
               echo "No dependencies to unpack"
             fi
@@ -145,13 +149,15 @@ jobs:
 
       - name: Create initial tag if none exists
         shell: bash
+        env:
+          CHARTS_DIR: ${{ inputs.charts_dir }}
         run: |
           set -euo pipefail
           # Check if any tags exist
           if ! git tag | grep -q .; then
             echo "No tags found, creating initial tag from Chart.yaml version"
             # Find first Chart.yaml and extract version
-            CHART_FILE=$(find charts -name "Chart.yaml" -type f | head -n 1)
+            CHART_FILE=$(find "${CHARTS_DIR}" -name "Chart.yaml" -type f | head -n 1)
             if [ -n "$CHART_FILE" ]; then
               VERSION=$(grep "^version:" "$CHART_FILE" | sed -E 's/^version:[[:space:]]*["'\'']?([^"'\'']+)["'\'']?[[:space:]]*$/\1/')
               if [ -n "$VERSION" ]; then
@@ -159,14 +165,14 @@ jobs:
                 echo "Creating tag ${TAG} from Chart.yaml version ${VERSION}"
                 git tag -a "${TAG}" -m "Initial tag for chart-releaser (from Chart.yaml)"
                 git push origin "${TAG}"
-                echo "✅ Created initial tag ${TAG}"
+                echo "Created initial tag ${TAG}"
               else
-                echo "⚠️  Could not extract version from Chart.yaml, using v0.0.0"
+                echo "Could not extract version from Chart.yaml, using v0.0.0"
                 git tag -a "v0.0.0" -m "Initial tag for chart-releaser"
                 git push origin "v0.0.0"
               fi
             else
-              echo "⚠️  No Chart.yaml found, using v0.0.0"
+              echo "No Chart.yaml found in ${CHARTS_DIR}, using v0.0.0"
               git tag -a "v0.0.0" -m "Initial tag for chart-releaser"
               git push origin "v0.0.0"
             fi

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -142,14 +142,20 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build image
+      # Scan path: single build + load, Trivy, then docker push (no rebuild).
+      # Non-scan / multi-platform path: build-push once with push:true.
+      - name: Build image for scan
+        if: inputs.scan-enabled
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a #v7.3.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           push: false
           load: true
-          tags: image:publish
+          tags: |
+            image:publish
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ inputs.platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -164,7 +170,19 @@ jobs:
           exit-code: "1"
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
 
-      - name: Push image
+      - name: Push scanned image
+        if: inputs.scan-enabled
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            echo "Pushing ${tag}"
+            docker push "$tag"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+      - name: Build and push image
+        if: ${{ !inputs.scan-enabled }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a #v7.3.0
         with:
           context: ${{ inputs.context }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -30,6 +30,11 @@ on:
         default: node_modules
         description: |
           a space separated list of directories and files to ignore
+      node-version:
+        type: string
+        required: false
+        default: '20'
+        description: Node.js version used to install markdownlint-cli
 
 jobs:
   markdown-lint:
@@ -37,6 +42,23 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Resolve npm global root
+        id: npm
+        run: echo "root=$(npm root -g)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache markdownlint-cli
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: |
+            ~/.npm
+            ${{ steps.npm.outputs.root }}
+          key: markdownlint-cli-0.41.0-${{ runner.os }}-node${{ inputs.node-version }}
 
       - id: lint
         env:

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       - name: Run yamllint
-        uses: karancode/yamllint-github-action@v3.0.0
+        uses: karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2 #v3.0.0
         with:
           yamllint_file_or_dir: ${{ inputs.yamllint_file_or_dir || '.' }}
           yamllint_config_filepath: ${{ inputs.yamllint_config_filepath || '.yamllint' }}


### PR DESCRIPTION
## Summary

- Pin floating actions to latest release SHAs:
  - `azure/setup-helm@v5.0.1`
  - `karancode/yamllint-github-action@v3.0.0`
  - `pozil/auto-assign-issue@v4.0.1`
- `docker-image-publish.yml`: build once, scan, then `docker push` (no rebuild); non-scan path still uses single build-push
- `markdown-lint.yml`: setup-node v7 + npm cache for `markdownlint-cli@0.41.0`
- `chart-lint-validate.yml`: honor `target_branch` (falls back to repo default branch)
- `chart-releaser.yml`: use `charts_dir` input (default `charts`) instead of hardcoded `charts/`

Closes #100