### PR TITLE
fix: chart workflow bugs and commitmsg base-ref

### DIFF
--- a/.github/workflows/chart-lint-validate.yml
+++ b/.github/workflows/chart-lint-validate.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       chart_dirs:
-        description: "Chart directory (relative path, defaults to repository root)"
+        description: "Chart directory relative to repository root (passed to ct --chart-dirs)"
         type: string
         required: false
-        default: "."
+        default: "charts"
       target_branch:
         description: "Target branch for chart-testing (defaults to repository default branch)"
         type: string
@@ -80,27 +80,31 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          changed=$(ct list-changed --target-branch ${{ steps.target.outputs.branch }})
+          changed=$(ct list-changed \
+            --target-branch "${{ steps.target.outputs.branch }}" \
+            --chart-dirs "${{ inputs.chart_dirs }}")
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Chart-Testing (lint)
-        if: ${{ steps.list-changed.outputs.changed == 'true' && (github.event_name == 'pull_request' || inputs.run_lint != false) }}
+        if: ${{ steps.list-changed.outputs.changed == 'true' && inputs.run_lint }}
         shell: bash
-        working-directory: ${{ inputs.chart_dirs }}
         run: |
           set -euo pipefail
-          ct lint --target-branch ${{ steps.target.outputs.branch }}
+          ct lint \
+            --target-branch "${{ steps.target.outputs.branch }}" \
+            --chart-dirs "${{ inputs.chart_dirs }}"
 
       - name: Create Kind cluster
-        if: ${{ steps.list-changed.outputs.changed == 'true' && (github.event_name == 'pull_request' || inputs.run_install != false) }}
+        if: ${{ steps.list-changed.outputs.changed == 'true' && inputs.run_install }}
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc #v1.14.0
 
       - name: Run Chart-Testing (install)
-        if: ${{ steps.list-changed.outputs.changed == 'true' && (github.event_name == 'pull_request' || inputs.run_install != false) }}
+        if: ${{ steps.list-changed.outputs.changed == 'true' && inputs.run_install }}
         shell: bash
-        working-directory: ${{ inputs.chart_dirs }}
         run: |
           set -euo pipefail
-          ct install --target-branch ${{ steps.target.outputs.branch }}
+          ct install \
+            --target-branch "${{ steps.target.outputs.branch }}" \
+            --chart-dirs "${{ inputs.chart_dirs }}"

--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -130,7 +130,8 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="gh-pages"
-          
+          SOURCE_SHA="$(git rev-parse HEAD)"
+
           # Check if branch exists remotely
           if git ls-remote --heads origin "${BRANCH}" | grep -q "${BRANCH}"; then
             echo "Branch ${BRANCH} already exists, skipping initialization"
@@ -144,7 +145,9 @@ jobs:
             git commit --allow-empty -m "Initialize ${BRANCH} branch"
             # Push the branch
             git push origin "${BRANCH}"
-            echo "✅ Created and pushed ${BRANCH} branch"
+            # Return to the source commit so later steps see charts/ source tree
+            git checkout --force "${SOURCE_SHA}"
+            echo "Created and pushed ${BRANCH} branch; restored ${SOURCE_SHA}"
           fi
 
       - name: Create initial tag if none exists

--- a/.github/workflows/commitmsg-conform.yml
+++ b/.github/workflows/commitmsg-conform.yml
@@ -58,9 +58,23 @@ jobs:
           cat << EOF > .conform.yaml
           ${{ inputs.config }}
           EOF
+      - name: Resolve commit-ref
+        id: commit-ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Prefer PR base branch; fall back to repository default branch.
+          if [[ -n "${{ github.base_ref }}" ]]; then
+            BASE="${{ github.base_ref }}"
+          else
+            BASE="${{ github.event.repository.default_branch }}"
+          fi
+          echo "ref=refs/remotes/origin/${BASE}" >> "$GITHUB_OUTPUT"
+          echo "Using commit-ref refs/remotes/origin/${BASE}"
       - name: conform
         env:
           INPUT_TOKEN: ${{ github.token }}
+          COMMIT_REF: ${{ steps.commit-ref.outputs.ref }}
         run: |
           docker run \
             -e "ACTIONS_CACHE_URL" \
@@ -121,4 +135,4 @@ jobs:
             -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" \
             --workdir /github/workspace \
             ghcr.io/siderolabs/conform:v0.1.0-alpha.30-1-ga6572d2 \
-            enforce --commit-ref="refs/remotes/origin/main" --reporter=github
+            enforce --commit-ref="$COMMIT_REF" --reporter=github


### PR DESCRIPTION
## Summary

- `chart-releaser.yml`: after creating `gh-pages`, check out the original SHA so tag/releaser steps still see charts
- `chart-lint-validate.yml`: pass `--chart-dirs` from repo root; default `chart_dirs` to `charts`; gate lint/install on `run_lint` / `run_install` only
- `commitmsg-conform.yml`: resolve `--commit-ref` from `github.base_ref` or repository default branch

Closes #102