### PR TITLE
fix: harden chart-releaser, terraform-tag, and astro-pages-deploy

### DIFF
--- a/.github/workflows/astro-pages-deploy.yml
+++ b/.github/workflows/astro-pages-deploy.yml
@@ -36,16 +36,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
+      - name: Set up Node.js
+        if: inputs.validate-command != '' || inputs.test-command != ''
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.path }}/package-lock.json
+
       - name: Install dependencies
         if: inputs.validate-command != '' || inputs.test-command != ''
-        run: npm ci
+        working-directory: ${{ inputs.path }}
+        run: npm ci --no-audit --no-fund
 
       - name: Validate
         if: inputs.validate-command != ''
+        working-directory: ${{ inputs.path }}
         run: ${{ inputs.validate-command }}
 
       - name: Test
         if: inputs.test-command != ''
+        working-directory: ${{ inputs.path }}
         run: ${{ inputs.test-command }}
 
       - name: Install, build, and upload site

--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           REPOS_FILE=$(mktemp)
-          
+
           # Extract repository URLs from Chart.yaml files
           find "${CHARTS_DIR}" -name "Chart.yaml" -type f | while IFS= read -r chart_file; do
             if grep -q "dependencies:" "$chart_file"; then
@@ -54,15 +54,15 @@ jobs:
                 grep -E '^https?://' >> "${REPOS_FILE}" || true
             fi
           done
-          
-          # Add unique repositories
+
+          # Add unique repositories (fail if helm repo add fails)
           if [ -s "${REPOS_FILE}" ]; then
             REPOS_ADDED=false
             while IFS= read -r repo_url; do
               repo_name=$(echo "$repo_url" | sed 's|https\?://||' | sed 's|/.*||' | sed 's|[^a-zA-Z0-9]|-|g' | tr '[:upper:]' '[:lower:]')
               if ! helm repo list 2>/dev/null | grep -q "^${repo_name}[[:space:]]"; then
                 echo "Adding Helm repository: ${repo_name} -> ${repo_url}"
-                helm repo add "${repo_name}" "${repo_url}" || true
+                helm repo add "${repo_name}" "${repo_url}"
                 REPOS_ADDED=true
               fi
             done < <(sort -u "${REPOS_FILE}")
@@ -71,7 +71,7 @@ jobs:
             echo "No dependencies found in ${CHARTS_DIR}, skipping repository addition"
             echo "repos_added=false" >> "$GITHUB_OUTPUT"
           fi
-          
+
           rm -f "${REPOS_FILE}"
 
       - name: Update Helm Repositories
@@ -87,38 +87,37 @@ jobs:
           for dir in "${CHARTS_DIR}"/*/; do
             [ ! -d "$dir" ] && continue
             echo "Processing chart: ${dir}"
-            
-            # Check if chart has dependencies
+
             if ! grep -q "dependencies:" "${dir}/Chart.yaml" 2>/dev/null; then
               echo "Chart has no dependencies, skipping"
               continue
             fi
-            
-            # Build or update dependencies
+
             if [ -f "${dir}/Chart.lock" ]; then
               echo "Chart.lock found, using helm dependency build"
-              if ! helm dependency build "$dir" 2>/dev/null; then
-                echo "Build failed, trying update instead"
-                helm dependency update "$dir" 2>/dev/null || echo "No dependencies to update"
+              if ! helm dependency build "$dir"; then
+                echo "Build failed, trying helm dependency update"
+                helm dependency update "$dir"
               fi
             else
               echo "Chart.lock not found, using helm dependency update"
-              helm dependency update "$dir" 2>/dev/null || echo "No dependencies to update"
+              helm dependency update "$dir"
             fi
-            
+
             # Unpack .tgz files to directories (chart-releaser expects unpacked dependencies)
             if [ -d "${dir}/charts" ] && [ -n "$(ls -A ${dir}/charts/*.tgz 2>/dev/null)" ]; then
               echo "Unpacking dependencies in ${dir}/charts"
-              cd "${dir}/charts"
-              for tgz in *.tgz; do
-                [ ! -f "$tgz" ] && continue
-                dirname="${tgz%.tgz}"
-                echo "  Unpacking ${tgz} -> ${dirname}/"
-                mkdir -p "${dirname}"
-                tar -xzf "${tgz}" -C "${dirname}" --strip-components=1
-                rm -f "${tgz}"
-              done
-              cd - > /dev/null
+              (
+                cd "${dir}/charts"
+                for tgz in *.tgz; do
+                  [ ! -f "$tgz" ] && continue
+                  dirname="${tgz%.tgz}"
+                  echo "  Unpacking ${tgz} -> ${dirname}/"
+                  mkdir -p "${dirname}"
+                  tar -xzf "${tgz}" -C "${dirname}" --strip-components=1
+                  rm -f "${tgz}"
+                done
+              )
               echo "Dependencies unpacked successfully"
             else
               echo "No dependencies to unpack"
@@ -132,53 +131,29 @@ jobs:
           BRANCH="gh-pages"
           SOURCE_SHA="$(git rev-parse HEAD)"
 
-          # Check if branch exists remotely
           if git ls-remote --heads origin "${BRANCH}" | grep -q "${BRANCH}"; then
             echo "Branch ${BRANCH} already exists, skipping initialization"
           else
             echo "Branch ${BRANCH} does not exist, creating it"
-            # Create orphan branch (no parent commits)
             git checkout --orphan "${BRANCH}"
-            # Remove all files from staging
             git rm -rf . || true
-            # Create initial commit
             git commit --allow-empty -m "Initialize ${BRANCH} branch"
-            # Push the branch
             git push origin "${BRANCH}"
-            # Return to the source commit so later steps see charts/ source tree
             git checkout --force "${SOURCE_SHA}"
             echo "Created and pushed ${BRANCH} branch; restored ${SOURCE_SHA}"
           fi
 
       - name: Create initial tag if none exists
         shell: bash
-        env:
-          CHARTS_DIR: ${{ inputs.charts_dir }}
         run: |
           set -euo pipefail
-          # Check if any tags exist
+          # Use sentinel v0.0.0 only — never Chart.yaml version, or chart-releaser
+          # may treat the current chart version as already released.
           if ! git tag | grep -q .; then
-            echo "No tags found, creating initial tag from Chart.yaml version"
-            # Find first Chart.yaml and extract version
-            CHART_FILE=$(find "${CHARTS_DIR}" -name "Chart.yaml" -type f | head -n 1)
-            if [ -n "$CHART_FILE" ]; then
-              VERSION=$(grep "^version:" "$CHART_FILE" | sed -E 's/^version:[[:space:]]*["'\'']?([^"'\'']+)["'\'']?[[:space:]]*$/\1/')
-              if [ -n "$VERSION" ]; then
-                TAG="v${VERSION}"
-                echo "Creating tag ${TAG} from Chart.yaml version ${VERSION}"
-                git tag -a "${TAG}" -m "Initial tag for chart-releaser (from Chart.yaml)"
-                git push origin "${TAG}"
-                echo "Created initial tag ${TAG}"
-              else
-                echo "Could not extract version from Chart.yaml, using v0.0.0"
-                git tag -a "v0.0.0" -m "Initial tag for chart-releaser"
-                git push origin "v0.0.0"
-              fi
-            else
-              echo "No Chart.yaml found in ${CHARTS_DIR}, using v0.0.0"
-              git tag -a "v0.0.0" -m "Initial tag for chart-releaser"
-              git push origin "v0.0.0"
-            fi
+            echo "No tags found, creating sentinel tag v0.0.0"
+            git tag -a "v0.0.0" -m "Initial sentinel tag for chart-releaser"
+            git push origin "v0.0.0"
+            echo "Created initial tag v0.0.0"
           else
             echo "Tags already exist, skipping initial tag creation"
           fi

--- a/.github/workflows/terraform-tag-and-release.yml
+++ b/.github/workflows/terraform-tag-and-release.yml
@@ -9,63 +9,7 @@ permissions:
 jobs:
   release:
     name: Terraform Tag and Release
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit changes (if any)
-        run: |
-          git add .
-          git commit -m "chore: update auto-generated files" || echo "No changes to commit"
-          git push
-
-      - name: Tag and release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git fetch --tags
-
-          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-
-          if [[ "$latest_tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            major="${BASH_REMATCH[1]}"
-            minor="${BASH_REMATCH[2]}"
-            patch="${BASH_REMATCH[3]}"
-
-            if (( patch < 99 )); then
-              patch=$((patch + 1))
-            else
-              patch=0
-              if (( minor < 99 )); then
-                minor=$((minor + 1))
-              else
-                minor=0
-                major=$((major + 1))
-              fi
-            fi
-          else
-            major=1
-            minor=0
-            patch=0
-          fi
-
-          new_tag="v${major}.${minor}.${patch}"
-          echo "New tag: $new_tag"
-
-          if [ -n "$latest_tag" ]; then
-            git log "$latest_tag"..HEAD --pretty=format:"- %s" > changelog.txt
-          else
-            git log --pretty=format:"- %s" > changelog.txt
-          fi
-
-          git tag "$new_tag"
-          git push origin "$new_tag"
-
-          gh release create "$new_tag" --title "$new_tag" --notes-file changelog.txt
+    uses: ./.github/workflows/terraform-tag.yml
+    with:
+      create-release: true
+    secrets: inherit

--- a/.github/workflows/terraform-tag.yml
+++ b/.github/workflows/terraform-tag.yml
@@ -2,6 +2,12 @@ name: terraform-tag
 
 on:
   workflow_call:
+    inputs:
+      create-release:
+        description: Create a GitHub Release for the new tag
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -14,22 +20,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit changes (if any)
         run: |
-          git add .
-          git commit -m "chore: update auto-generated files" || echo "No changes to commit"
+          set -euo pipefail
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          # Stage updates to tracked files only (avoid committing unrelated untracked files)
+          git add -u
+          if git diff --cached --quiet; then
+            echo "No tracked-file changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: update auto-generated files" \
+            -m "Commit documentation and other generated files produced by the preceding workflow before tagging a new module version."
           git push
 
       - name: Tag
+        id: tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           git fetch --tags
 
           latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
@@ -58,6 +80,7 @@ jobs:
 
           new_tag="v${major}.${minor}.${patch}"
           echo "New tag: $new_tag"
+          echo "tag=${new_tag}" >> "$GITHUB_OUTPUT"
 
           if [ -n "$latest_tag" ]; then
             git log "$latest_tag"..HEAD --pretty=format:"- %s" > changelog.txt
@@ -67,3 +90,13 @@ jobs:
 
           git tag "$new_tag"
           git push origin "$new_tag"
+
+      - name: Create GitHub Release
+        if: ${{ inputs.create-release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --title "${{ steps.tag.outputs.tag }}" \
+            --notes-file changelog.txt


### PR DESCRIPTION
## Summary

- `chart-releaser.yml`: fail on helm repo/dependency errors; seed tags with `v0.0.0` only
- `terraform-tag.yml`: `fetch-depth: 0`, `git add -u`, commit with body; optional `create-release`
- `terraform-tag-and-release.yml`: thin caller of `terraform-tag` with `create-release: true`
- `astro-pages-deploy.yml`: `setup-node` + `npm ci` under `inputs.path` before validate/test

Closes #104