### PR TITLE
feat: add jekyll-pages-deploy reusable

### DIFF
--- a/.github/workflows/jekyll-pages-deploy.yml
+++ b/.github/workflows/jekyll-pages-deploy.yml
@@ -1,0 +1,70 @@
+name: jekyll-pages-deploy
+
+on:
+  workflow_call:
+    inputs:
+      source:
+        description: Directory where the Jekyll source files reside
+        type: string
+        required: false
+        default: "./"
+      destination:
+        description: Jekyll build output directory (uploaded as the Pages artifact)
+        type: string
+        required: false
+        default: "./_site"
+      artifact-name:
+        description: Name of the Pages artifact to upload and deploy
+        type: string
+        required: false
+        default: "github-pages"
+      retention-days:
+        description: Number of days to retain the uploaded artifact
+        type: string
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d #v6.0.0
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 #v1.0.13
+        with:
+          source: ${{ inputs.source }}
+          destination: ${{ inputs.destination }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 #v5.0.0
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.destination }}
+          retention-days: ${{ inputs.retention-days }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 #v5.0.0
+        with:
+          artifact_name: ${{ inputs.artifact-name }}


### PR DESCRIPTION
## Summary
- Add `jekyll-pages-deploy` reusable: checkout → configure-pages → jekyll-build-pages → upload-pages-artifact → deploy-pages
- SHA-pin marketplace actions; optional `source` / `destination` / artifact inputs
- Concurrency lives on the reusable (callers must not also use `group: pages`)

## Test plan
- [ ] CI on this PR passes
- [ ] Follow-up: migrate `jajera/jekyll` to call this reusable

Closes #106