### PR TITLE
fix: correct markdown-lint MD024 rule name in defaults

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,7 +18,8 @@ on:
             "no-bare-urls": false,
             "fenced-code-language": false,
             "first-line-h1": false,
-            "no-duplicate-header": false,
+            "no-duplicate-heading": false,
+            "blanks-around-headings": false,
             "no-emphasis-as-header": false,
             "single-h1": false
           }


### PR DESCRIPTION
## Summary
- Rename default disable `no-duplicate-header` → `no-duplicate-heading` (MD024)
- Also disable `blanks-around-headings` (MD022) for short README demos

## Test plan
- [ ] Self-test / markdown-lint workflow passes
- [ ] Re-run failing consumer PRs after merge

Closes #110