### PR TITLE
feat: add terraform-drift reusable workflow

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -1,0 +1,268 @@
+name: terraform-drift
+
+# Detect Terraform drift via plan, open a GitHub issue when changes exist.
+# Callers should schedule this workflow and pass secrets: inherit.
+#
+# Expects caller repo secrets/vars (via inherit):
+#   secrets.AWS_ACCOUNT_ID
+#   vars.OIDC_ROLE_NAME
+#   vars.AWS_REGION
+#   vars.TERRAFORM_VERSION
+# Optional TF_VAR_* secrets (empty when unused): VERCEL_*, *_ACCOUNT_EMAIL, etc.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Path to the Terraform configuration directory
+        type: string
+        required: false
+        default: "."
+      environment-label:
+        description: Optional label included in the drift issue title (e.g. env name)
+        type: string
+        required: false
+        default: ""
+      aws-region:
+        description: AWS region for OIDC (defaults to vars.AWS_REGION)
+        type: string
+        required: false
+        default: ""
+      terraform-version:
+        description: Terraform version (defaults to vars.TERRAFORM_VERSION)
+        type: string
+        required: false
+        default: ""
+      init-upgrade:
+        description: Run terraform init -upgrade
+        type: boolean
+        required: false
+        default: false
+      create-issue:
+        description: Open a GitHub issue when drift is detected
+        type: boolean
+        required: false
+        default: true
+      issue-labels:
+        description: Comma-separated labels for the drift issue
+        type: string
+        required: false
+        default: "terraform,drift"
+      slack-notify:
+        description: Send Slack notification via Bitwarden Secrets Manager webhook
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    env:
+      # Optional TF_VAR pass-through (blank when secret absent)
+      TF_VAR_vercel_api_token: ${{ secrets.VERCEL_API_TOKEN }}
+      TF_VAR_github_pat: ${{ secrets.VERCEL_GITHUB_PAT }}
+      TF_VAR_sandbox_account_email: ${{ secrets.SANDBOX_ACCOUNT_EMAIL }}
+      TF_VAR_dev_account_email: ${{ secrets.DEV_ACCOUNT_EMAIL }}
+      TF_VAR_network_account_email: ${{ secrets.NETWORK_ACCOUNT_EMAIL }}
+      TF_VAR_shared_services_account_email: ${{ secrets.SHARED_SERVICES_ACCOUNT_EMAIL }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ vars.OIDC_ROLE_NAME }}
+          aws-region: ${{ inputs.aws-region != '' && inputs.aws-region || vars.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: ${{ inputs.terraform-version != '' && inputs.terraform-version || vars.TERRAFORM_VERSION }}
+
+      - name: Terraform Init
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ "${{ inputs.init-upgrade }}" = "true" ]; then
+            terraform init -upgrade
+          else
+            terraform init
+          fi
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: ${{ inputs.working-directory }}
+        continue-on-error: true
+        run: |
+          set +e
+          PLAN_OUTPUT=$(terraform plan -no-color 2>&1)
+          PLAN_EXIT_CODE=$?
+          set -e
+
+          {
+            echo "plan_output<<EOF"
+            echo "$PLAN_OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if echo "$PLAN_OUTPUT" | grep -q "No changes"; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$PLAN_EXIT_CODE" -ne 0 ]; then
+            echo "has_errors=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_errors=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Issue if Drift Detected
+        if: inputs.create-issue && steps.plan.outputs.has_changes == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLAN_OUTPUT: ${{ steps.plan.outputs.plan_output }}
+          ENVIRONMENT_LABEL: ${{ inputs.environment-label }}
+          ISSUE_LABELS: ${{ inputs.issue-labels }}
+        with:
+          script: |
+            const planOutput = process.env.PLAN_OUTPUT || '';
+            const envLabel = (process.env.ENVIRONMENT_LABEL || '').trim();
+            const date = new Date().toISOString().split('T')[0];
+            const title = envLabel
+              ? `Terraform Drift Detected (${envLabel}) - ${date}`
+              : `Terraform Drift Detected - ${date}`;
+            const labels = (process.env.ISSUE_LABELS || 'terraform,drift')
+              .split(',')
+              .map((l) => l.trim())
+              .filter(Boolean);
+            const body = [
+              '## Terraform Drift Detected',
+              '',
+              envLabel ? `**Environment:** \`${envLabel}\`` : null,
+              '',
+              'Drift was detected in the infrastructure. Here are the planned changes:',
+              '',
+              '```',
+              planOutput,
+              '```',
+              '',
+              'Please review these changes and take appropriate action.',
+            ].filter((line) => line !== null).join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels,
+            });
+
+      - name: Get SLACK_WEBHOOK_URL from Bitwarden Secrets
+        if: inputs.slack-notify && steps.plan.outputs.has_changes == 'true'
+        uses: bitwarden/sm-action@1238aae8fc64b212641190a9227c8a734ab1a793 # v3.0.1
+        with:
+          access_token: ${{ secrets.BW_ACCESS_TOKEN }}
+          base_url: https://vault.bitwarden.com
+          secrets: |
+            ${{ secrets.BW_SLACK_WEBHOOK_SECRET_ID }} > SLACK_WEBHOOK_URL
+
+      - name: Send Slack Notification if Drift Detected
+        if: inputs.slack-notify && steps.plan.outputs.has_changes == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLAN_OUTPUT: ${{ steps.plan.outputs.plan_output }}
+          ENVIRONMENT_LABEL: ${{ inputs.environment-label }}
+        with:
+          script: |
+            const planOutput = process.env.PLAN_OUTPUT || '';
+            const envLabel = (process.env.ENVIRONMENT_LABEL || '').trim();
+            const lines = planOutput.split('\n');
+            const planLine = lines.find((line) => /^Plan:/.test(line.trim()));
+            const messageContent = planLine
+              ? planLine.trim()
+              : 'Drift detected. See workflow run for details.';
+            const currentTime = new Date().toISOString();
+            const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const headerText = envLabel
+              ? `Terraform Drift Detected (${envLabel})`
+              : 'Terraform Drift Detected';
+
+            const slackPayload = {
+              blocks: [
+                {
+                  type: 'header',
+                  text: { type: 'plain_text', text: headerText, emoji: true },
+                },
+                {
+                  type: 'section',
+                  fields: [
+                    { type: 'mrkdwn', text: `*Time:*\n\`${currentTime}\`` },
+                    { type: 'mrkdwn', text: `*Repository:*\n\`${context.repo.owner}/${context.repo.repo}\`` },
+                  ],
+                },
+                {
+                  type: 'section',
+                  text: { type: 'mrkdwn', text: `*Plan Summary:*\n\`${messageContent}\`` },
+                },
+                {
+                  type: 'section',
+                  text: { type: 'mrkdwn', text: 'Please review and take appropriate action.' },
+                },
+                {
+                  type: 'actions',
+                  elements: [
+                    {
+                      type: 'button',
+                      text: { type: 'plain_text', text: 'View Workflow Run', emoji: true },
+                      url: workflowUrl,
+                    },
+                  ],
+                },
+              ],
+            };
+
+            const https = require('https');
+            const { URL } = require('url');
+            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+            if (!webhookUrl) {
+              console.log('SLACK_WEBHOOK_URL not set - skipping Slack notification');
+              return;
+            }
+
+            const parsedUrl = new URL(webhookUrl);
+            const payload = JSON.stringify(slackPayload);
+            await new Promise((resolve, reject) => {
+              const req = https.request(
+                {
+                  hostname: parsedUrl.hostname,
+                  path: parsedUrl.pathname + parsedUrl.search,
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': Buffer.byteLength(payload),
+                  },
+                },
+                (res) => {
+                  res.resume();
+                  res.on('end', () => {
+                    if (res.statusCode >= 200 && res.statusCode < 300) resolve();
+                    else reject(new Error(`Slack webhook failed: ${res.statusCode}`));
+                  });
+                },
+              );
+              req.on('error', () => reject(new Error('Slack webhook request failed')));
+              req.setTimeout(10000, () => {
+                req.destroy();
+                reject(new Error('Slack webhook request timed out'));
+              });
+              req.write(payload);
+              req.end();
+            }).catch((error) => {
+              console.log(`Failed to send Slack notification: ${error.message}`);
+            });


### PR DESCRIPTION
## Summary
- Add `terraform-drift.yml` reusable workflow for scheduled drift detection
- AWS OIDC + terraform init/plan + optional GitHub issue and Slack notify
- Supports `working-directory`, matrix-friendly `environment-label`, and `init-upgrade`

## Test plan
- [ ] Workflow YAML validates in Actions
- [ ] Follow-up PRs in platformfuzz/jobpulse-nz call this reusable