### PR TITLE
refactor: split slack notify and optional bitwarden webhook

### DIFF
--- a/.github/workflows/bitwarden-get-secret.yml
+++ b/.github/workflows/bitwarden-get-secret.yml
@@ -1,0 +1,84 @@
+name: bitwarden-get-secret
+
+# Fetch a single secret from Bitwarden Secrets Manager into a job output.
+# Prefer notify-slack (webhook-source: bitwarden) for Slack webhooks.
+#
+# secrets: inherit expects:
+#   BW_ACCESS_TOKEN
+#   BW_SECRET_ID — Bitwarden secret UUID to fetch
+#     (or set secret-id-secret: BW_SLACK_WEBHOOK_SECRET_ID)
+
+on:
+  workflow_call:
+    inputs:
+      secret-id-secret:
+        description: GitHub secret name that holds the Bitwarden secret UUID
+        type: string
+        required: false
+        default: "BW_SECRET_ID"
+      env-name:
+        description: Name used when exporting the fetched value from sm-action
+        type: string
+        required: false
+        default: "SECRET_VALUE"
+      base-url:
+        description: Bitwarden Secrets Manager API base URL
+        type: string
+        required: false
+        default: "https://vault.bitwarden.com"
+    outputs:
+      value:
+        description: Fetched secret value (masked)
+        value: ${{ jobs.fetch.outputs.value }}
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.read.outputs.value }}
+    steps:
+      - name: Resolve Bitwarden secret UUID
+        id: id
+        env:
+          BW_SECRET_ID: ${{ secrets.BW_SECRET_ID }}
+          BW_SLACK_WEBHOOK_SECRET_ID: ${{ secrets.BW_SLACK_WEBHOOK_SECRET_ID }}
+          SECRET_ID_SECRET: ${{ inputs.secret-id-secret }}
+        run: |
+          set -euo pipefail
+          case "$SECRET_ID_SECRET" in
+            BW_SECRET_ID) value="${BW_SECRET_ID:-}" ;;
+            BW_SLACK_WEBHOOK_SECRET_ID) value="${BW_SLACK_WEBHOOK_SECRET_ID:-}" ;;
+            *)
+              echo "Unsupported secret-id-secret '$SECRET_ID_SECRET'"
+              echo "Supported: BW_SECRET_ID, BW_SLACK_WEBHOOK_SECRET_ID"
+              exit 1
+              ;;
+          esac
+          if [ -z "$value" ]; then
+            echo "GitHub secret $SECRET_ID_SECRET is empty"
+            exit 1
+          fi
+          echo "::add-mask::$value"
+          echo "uuid=$value" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch secret from Bitwarden
+        uses: bitwarden/sm-action@1238aae8fc64b212641190a9227c8a734ab1a793 # v3.0.1
+        with:
+          access_token: ${{ secrets.BW_ACCESS_TOKEN }}
+          base_url: ${{ inputs.base-url }}
+          secrets: |
+            ${{ steps.id.outputs.uuid }} > ${{ inputs.env-name }}
+
+      - name: Export value
+        id: read
+        env:
+          ENV_NAME: ${{ inputs.env-name }}
+        run: |
+          set -euo pipefail
+          value="${!ENV_NAME}"
+          echo "::add-mask::$value"
+          {
+            echo "value<<EOF"
+            printf '%s\n' "$value"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,177 @@
+name: notify-slack
+
+# Post a Slack message via Incoming Webhook.
+# Webhook URL is resolved from either:
+#   webhook-source: github   → secrets.SLACK_WEBHOOK_URL
+#   webhook-source: bitwarden → Bitwarden SM (BW_ACCESS_TOKEN + BW_SLACK_WEBHOOK_SECRET_ID)
+#
+# Call with secrets: inherit.
+
+on:
+  workflow_call:
+    inputs:
+      title:
+        description: Slack message header
+        type: string
+        required: true
+      text:
+        description: Primary message body (mrkdwn-friendly plain text)
+        type: string
+        required: true
+      webhook-source:
+        description: Where to load the webhook URL from (github or bitwarden)
+        type: string
+        required: false
+        default: "github"
+      include-run-link:
+        description: Include a button linking to the triggering workflow run
+        type: boolean
+        required: false
+        default: true
+      fail-on-error:
+        description: Fail the job if Slack delivery fails
+        type: boolean
+        required: false
+        default: false
+      bitwarden-base-url:
+        description: Bitwarden Secrets Manager API base URL
+        type: string
+        required: false
+        default: "https://vault.bitwarden.com"
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate webhook-source
+        run: |
+          set -euo pipefail
+          src="${{ inputs.webhook-source }}"
+          if [ "$src" != "github" ] && [ "$src" != "bitwarden" ]; then
+            echo "webhook-source must be 'github' or 'bitwarden' (got: $src)"
+            exit 1
+          fi
+
+      - name: Resolve webhook from GitHub secret
+        if: inputs.webhook-source == 'github'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "SLACK_WEBHOOK_URL secret is empty"
+            exit 1
+          fi
+          echo "::add-mask::$SLACK_WEBHOOK_URL"
+          echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" >> "$GITHUB_ENV"
+
+      - name: Resolve webhook from Bitwarden
+        if: inputs.webhook-source == 'bitwarden'
+        uses: bitwarden/sm-action@1238aae8fc64b212641190a9227c8a734ab1a793 # v3.0.1
+        with:
+          access_token: ${{ secrets.BW_ACCESS_TOKEN }}
+          base_url: ${{ inputs.bitwarden-base-url }}
+          secrets: |
+            ${{ secrets.BW_SLACK_WEBHOOK_SECRET_ID }} > SLACK_WEBHOOK_URL
+
+      - name: Send Slack notification
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TITLE: ${{ inputs.title }}
+          TEXT: ${{ inputs.text }}
+          INCLUDE_RUN_LINK: ${{ inputs.include-run-link }}
+          FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        with:
+          script: |
+            const https = require('https');
+            const { URL } = require('url');
+
+            const title = process.env.TITLE || 'Notification';
+            const text = process.env.TEXT || '';
+            const includeRunLink = process.env.INCLUDE_RUN_LINK === 'true';
+            const failOnError = process.env.FAIL_ON_ERROR === 'true';
+            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+            if (!webhookUrl) {
+              const msg = 'SLACK_WEBHOOK_URL not set after webhook resolve';
+              if (failOnError) throw new Error(msg);
+              console.log(msg + ' - skipping');
+              return;
+            }
+
+            const currentTime = new Date().toISOString();
+            const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const blocks = [
+              {
+                type: 'header',
+                text: { type: 'plain_text', text: title.slice(0, 150), emoji: true },
+              },
+              {
+                type: 'section',
+                fields: [
+                  { type: 'mrkdwn', text: `*Time:*\n\`${currentTime}\`` },
+                  {
+                    type: 'mrkdwn',
+                    text: `*Repository:*\n\`${context.repo.owner}/${context.repo.repo}\``,
+                  },
+                ],
+              },
+              {
+                type: 'section',
+                text: { type: 'mrkdwn', text: text || '_No details provided._' },
+              },
+            ];
+
+            if (includeRunLink) {
+              blocks.push({
+                type: 'actions',
+                elements: [
+                  {
+                    type: 'button',
+                    text: { type: 'plain_text', text: 'View Workflow Run', emoji: true },
+                    url: workflowUrl,
+                  },
+                ],
+              });
+            }
+
+            const payload = JSON.stringify({ blocks });
+            const parsedUrl = new URL(webhookUrl);
+
+            try {
+              await new Promise((resolve, reject) => {
+                const req = https.request(
+                  {
+                    hostname: parsedUrl.hostname,
+                    path: parsedUrl.pathname + parsedUrl.search,
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'Content-Length': Buffer.byteLength(payload),
+                    },
+                  },
+                  (res) => {
+                    res.resume();
+                    res.on('end', () => {
+                      if (res.statusCode >= 200 && res.statusCode < 300) resolve();
+                      else reject(new Error(`Slack webhook failed: ${res.statusCode}`));
+                    });
+                  },
+                );
+                req.on('error', () => reject(new Error('Slack webhook request failed')));
+                req.setTimeout(10000, () => {
+                  req.destroy();
+                  reject(new Error('Slack webhook request timed out'));
+                });
+                req.write(payload);
+                req.end();
+              });
+              console.log('Slack notification sent successfully');
+            } catch (error) {
+              if (failOnError) throw error;
+              console.log(`Failed to send Slack notification: ${error.message}`);
+            }

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -2,6 +2,7 @@ name: terraform-drift
 
 # Detect Terraform drift via plan, open a GitHub issue when changes exist.
 # Callers should schedule this workflow and pass secrets: inherit.
+# For Slack, call notify-slack separately when outputs.has_changes == 'true'.
 #
 # Expects caller repo secrets/vars (via inherit):
 #   secrets.AWS_ACCOUNT_ID
@@ -48,11 +49,19 @@ on:
         type: string
         required: false
         default: "terraform,drift"
-      slack-notify:
-        description: Send Slack notification via Bitwarden Secrets Manager webhook
-        type: boolean
-        required: false
-        default: false
+    outputs:
+      has_changes:
+        description: Whether terraform plan reported changes
+        value: ${{ jobs.drift.outputs.has_changes }}
+      has_errors:
+        description: Whether terraform plan exited non-zero
+        value: ${{ jobs.drift.outputs.has_errors }}
+      plan_summary:
+        description: Short plan summary line (e.g. Plan: 0 to add, …)
+        value: ${{ jobs.drift.outputs.plan_summary }}
+      environment_label:
+        description: Echo of environment-label input
+        value: ${{ jobs.drift.outputs.environment_label }}
 
 permissions:
   id-token: write
@@ -62,6 +71,11 @@ permissions:
 jobs:
   drift:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.plan.outputs.has_changes }}
+      has_errors: ${{ steps.plan.outputs.has_errors }}
+      plan_summary: ${{ steps.plan.outputs.plan_summary }}
+      environment_label: ${{ steps.meta.outputs.environment_label }}
     env:
       # Optional TF_VAR pass-through (blank when secret absent)
       TF_VAR_vercel_api_token: ${{ secrets.VERCEL_API_TOKEN }}
@@ -71,6 +85,10 @@ jobs:
       TF_VAR_network_account_email: ${{ secrets.NETWORK_ACCOUNT_EMAIL }}
       TF_VAR_shared_services_account_email: ${{ secrets.SHARED_SERVICES_ACCOUNT_EMAIL }}
     steps:
+      - name: Record metadata
+        id: meta
+        run: echo "environment_label=${{ inputs.environment-label }}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -109,6 +127,12 @@ jobs:
             echo "$PLAN_OUTPUT"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+          SUMMARY=$(echo "$PLAN_OUTPUT" | grep -E '^Plan:' | head -n1 || true)
+          if [ -z "$SUMMARY" ]; then
+            SUMMARY="Drift detected. See workflow run for details."
+          fi
+          echo "plan_summary=$SUMMARY" >> "$GITHUB_OUTPUT"
 
           if echo "$PLAN_OUTPUT" | grep -q "No changes"; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -161,108 +185,4 @@ jobs:
               title,
               body,
               labels,
-            });
-
-      - name: Get SLACK_WEBHOOK_URL from Bitwarden Secrets
-        if: inputs.slack-notify && steps.plan.outputs.has_changes == 'true'
-        uses: bitwarden/sm-action@1238aae8fc64b212641190a9227c8a734ab1a793 # v3.0.1
-        with:
-          access_token: ${{ secrets.BW_ACCESS_TOKEN }}
-          base_url: https://vault.bitwarden.com
-          secrets: |
-            ${{ secrets.BW_SLACK_WEBHOOK_SECRET_ID }} > SLACK_WEBHOOK_URL
-
-      - name: Send Slack Notification if Drift Detected
-        if: inputs.slack-notify && steps.plan.outputs.has_changes == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          PLAN_OUTPUT: ${{ steps.plan.outputs.plan_output }}
-          ENVIRONMENT_LABEL: ${{ inputs.environment-label }}
-        with:
-          script: |
-            const planOutput = process.env.PLAN_OUTPUT || '';
-            const envLabel = (process.env.ENVIRONMENT_LABEL || '').trim();
-            const lines = planOutput.split('\n');
-            const planLine = lines.find((line) => /^Plan:/.test(line.trim()));
-            const messageContent = planLine
-              ? planLine.trim()
-              : 'Drift detected. See workflow run for details.';
-            const currentTime = new Date().toISOString();
-            const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const headerText = envLabel
-              ? `Terraform Drift Detected (${envLabel})`
-              : 'Terraform Drift Detected';
-
-            const slackPayload = {
-              blocks: [
-                {
-                  type: 'header',
-                  text: { type: 'plain_text', text: headerText, emoji: true },
-                },
-                {
-                  type: 'section',
-                  fields: [
-                    { type: 'mrkdwn', text: `*Time:*\n\`${currentTime}\`` },
-                    { type: 'mrkdwn', text: `*Repository:*\n\`${context.repo.owner}/${context.repo.repo}\`` },
-                  ],
-                },
-                {
-                  type: 'section',
-                  text: { type: 'mrkdwn', text: `*Plan Summary:*\n\`${messageContent}\`` },
-                },
-                {
-                  type: 'section',
-                  text: { type: 'mrkdwn', text: 'Please review and take appropriate action.' },
-                },
-                {
-                  type: 'actions',
-                  elements: [
-                    {
-                      type: 'button',
-                      text: { type: 'plain_text', text: 'View Workflow Run', emoji: true },
-                      url: workflowUrl,
-                    },
-                  ],
-                },
-              ],
-            };
-
-            const https = require('https');
-            const { URL } = require('url');
-            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
-            if (!webhookUrl) {
-              console.log('SLACK_WEBHOOK_URL not set - skipping Slack notification');
-              return;
-            }
-
-            const parsedUrl = new URL(webhookUrl);
-            const payload = JSON.stringify(slackPayload);
-            await new Promise((resolve, reject) => {
-              const req = https.request(
-                {
-                  hostname: parsedUrl.hostname,
-                  path: parsedUrl.pathname + parsedUrl.search,
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'Content-Length': Buffer.byteLength(payload),
-                  },
-                },
-                (res) => {
-                  res.resume();
-                  res.on('end', () => {
-                    if (res.statusCode >= 200 && res.statusCode < 300) resolve();
-                    else reject(new Error(`Slack webhook failed: ${res.statusCode}`));
-                  });
-                },
-              );
-              req.on('error', () => reject(new Error('Slack webhook request failed')));
-              req.setTimeout(10000, () => {
-                req.destroy();
-                reject(new Error('Slack webhook request timed out'));
-              });
-              req.write(payload);
-              req.end();
-            }).catch((error) => {
-              console.log(`Failed to send Slack notification: ${error.message}`);
             });


### PR DESCRIPTION
## Summary
- Add `notify-slack.yml` with `webhook-source: github | bitwarden`
- Add `bitwarden-get-secret.yml` for standalone Bitwarden fetches
- Remove Slack/Bitwarden from `terraform-drift.yml`; add job outputs for chaining

## Test plan
- [ ] Hygiene checks pass
- [ ] Follow-up: `platformfuzz/terraform-aws` chains drift → notify-slack (bitwarden)