### PR TITLE
feat: add docker-image-release reusable workflow

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -1,0 +1,108 @@
+name: docker-image-release
+
+# Build/push a GHCR image (semver + sha + latest) and create a GitHub Release on tags.
+# Distinct from docker-image-publish (scan/ECR-focused): this matches platformfuzz
+# *-image build-and-release.yml (push + softprops GH release, no Trivy).
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: Image name without registry (defaults to github.repository)
+        type: string
+        required: false
+        default: ""
+      image-suffix:
+        description: Optional suffix appended to the image name (e.g. -test)
+        type: string
+        required: false
+        default: ""
+      dockerfile:
+        description: Path to the Dockerfile
+        type: string
+        required: false
+        default: "Dockerfile"
+      context:
+        description: Docker build context
+        type: string
+        required: false
+        default: "."
+      build-args:
+        description: Docker build-args (multiline KEY=value), optional
+        type: string
+        required: false
+        default: ""
+      platforms:
+        description: Target platforms for the build
+        type: string
+        required: false
+        default: "linux/amd64"
+      create-release:
+        description: Create a GitHub Release when the ref is a tag
+        type: boolean
+        required: false
+        default: true
+      generate-release-notes:
+        description: Autogenerate GitHub Release notes
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Lowercase image name (GHCR)
+        run: |
+          NAME="${{ inputs.image-name != '' && inputs.image-name || github.repository }}"
+          echo "IMAGE_REF=ghcr.io/$(echo "${NAME}${{ inputs.image-suffix }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.IMAGE_REF }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ inputs.platforms }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create Release
+        if: inputs.create-release && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          generate_release_notes: ${{ inputs.generate-release-notes }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `docker-image-release.yml` for GHCR build/push with semver tags plus softprops GitHub Release on tags
- Inputs cover dockerfile, context, build-args, image-suffix, and optional release creation (for matrix callers like mkdocs)
- Distinct from `docker-image-publish` (no Trivy/ECR) — matches platformfuzz `*-image` build-and-release workflows

## Test plan
- [ ] Workflow YAML validates in CI
- [ ] Follow-up: migrate platformfuzz image repos to call this reusable