### PR TITLE
chore: bump setup-node and terraform-validate majors

### DIFF
--- a/.github/workflows/node-ci-workflow.yml
+++ b/.github/workflows/node-ci-workflow.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/terraform-lint-validate.yml
+++ b/.github/workflows/terraform-lint-validate.yml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       - name: Validate Terraform Configuration
-        uses: dflook/terraform-validate@4cef5d8a4b92bcd88486e41e22a42942a382c9d6 #v2.2.3
+        uses: dflook/terraform-validate@36ef08d500fe2cd9b742b10176d2683707c7074e #v3.0.0
         with:
           path: ${{ inputs.path }}


### PR DESCRIPTION
## Summary
- `node-ci-workflow.yml`: `actions/setup-node` v6.4.0 → v7.0.0
- `terraform-lint-validate.yml`: `dflook/terraform-validate` v2.2.3 → v3.0.0

## Test plan
- [ ] Conform / markdown-lint CI pass