### PR TITLE
fix: require explicit GH_ORG_TOKEN for gh-teams-sync

### DIFF
--- a/.github/workflows/gh-teams-sync.yml
+++ b/.github/workflows/gh-teams-sync.yml
@@ -1,8 +1,8 @@
 name: gh-teams-sync
 
 # Sync GitHub org teams from a declarative YAML file via
-# actionsforge/actions-gh-teams-sync. Call with secrets: inherit
-# (requires GH_ORG_TOKEN on the caller).
+# actionsforge/actions-gh-teams-sync. Callers must pass GH_ORG_TOKEN
+# explicitly (secrets: inherit is unreliable across organizations).
 
 on:
   workflow_call:
@@ -17,6 +17,10 @@ on:
         type: boolean
         required: false
         default: false
+    secrets:
+      GH_ORG_TOKEN:
+        description: PAT with admin:org (and repo) for team membership sync
+        required: true
 
 permissions:
   contents: read
@@ -27,6 +31,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Require GH_ORG_TOKEN
+        env:
+          GH_ORG_TOKEN: ${{ secrets.GH_ORG_TOKEN }}
+        run: |
+          if [ -z "${GH_ORG_TOKEN}" ]; then
+            echo "::error::GH_ORG_TOKEN secret is empty. Set a PAT with admin:org on the calling repo."
+            exit 1
+          fi
 
       - name: GitHub Teams Sync
         uses: actionsforge/actions-gh-teams-sync@v1


### PR DESCRIPTION
## Summary
- Cross-org callers (`platformfuzz/gh-team-sync`, `cloudbuildlab/gh-team-sync`) using `secrets: inherit` resolve `GH_ORG_TOKEN` as empty → `Missing GITHUB_TOKEN` ([platformfuzz run](https://github.com/platformfuzz/gh-team-sync/actions/runs/30182685980))
- Declare `GH_ORG_TOKEN` on `workflow_call.secrets` and require callers to pass it explicitly
- Add a preflight step with a clear error if the secret is empty

## Test plan
- [ ] Merge, then update callers to `secrets: { GH_ORG_TOKEN: ${{ secrets.GH_ORG_TOKEN }} }`
- [ ] Re-run GitHub Teams Sync on platformfuzz/gh-team-sync