### PR TITLE
fix: quote terraform-drift plan_summary description

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -57,7 +57,7 @@ on:
         description: Whether terraform plan exited non-zero
         value: ${{ jobs.drift.outputs.has_errors }}
       plan_summary:
-        description: Short plan summary line (e.g. Plan: 0 to add, …)
+        description: "Short plan summary line (e.g. Plan: 0 to add, …)"
         value: ${{ jobs.drift.outputs.plan_summary }}
       environment_label:
         description: Echo of environment-label input


### PR DESCRIPTION
## Summary
- Unquoted `Plan: 0` in `terraform-drift.yml` made the file invalid YAML
- That failed workflow validation ([#30183022852](https://github.com/actionsforge/actions/actions/runs/30183022852)) and Dependabot (`dependency_file_not_parseable`, [#30177096677](https://github.com/actionsforge/actions/actions/runs/30177096677))

Closes #127

## Test plan
- [ ] CI green
- [ ] YAML loads cleanly
- [ ] Trigger Dependabot after merge and confirm github-actions update succeeds