### PR TITLE
chore: retrigger Dependabot after terraform-drift YAML fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# manual-trigger: 2026-07-25T22:11:30.057Z
+# manual-trigger: 2026-07-27T09:59:32.647Z
 version: 2
 updates:
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Nudge Dependabot after #128 fixed `dependency_file_not_parseable` on `terraform-drift.yml`

Closes #129

## Test plan
- [ ] CI green
- [ ] Dependabot Updates run succeeds after merge