### PR TITLE
fix: require explicit secrets for terraform-drift OIDC

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -1,15 +1,13 @@
 name: terraform-drift
 
 # Detect Terraform drift via plan, open a GitHub issue when changes exist.
-# Callers should schedule this workflow and pass secrets: inherit.
+# Callers must pass secrets explicitly (secrets: inherit is unreliable across orgs).
 # For Slack, call notify-slack separately when outputs.has_changes == 'true'.
 #
-# Expects caller repo secrets/vars (via inherit):
-#   secrets.AWS_ACCOUNT_ID
-#   vars.OIDC_ROLE_NAME
-#   vars.AWS_REGION
-#   vars.TERRAFORM_VERSION
-# Optional TF_VAR_* secrets (empty when unused): VERCEL_*, *_ACCOUNT_EMAIL, etc.
+# Expects caller repo:
+#   secrets.AWS_ACCOUNT_ID (required)
+#   vars.OIDC_ROLE_NAME, vars.AWS_REGION, vars.TERRAFORM_VERSION
+# Optional TF_VAR_* secrets (omit when unused): VERCEL_*, *_ACCOUNT_EMAIL, etc.
 
 on:
   workflow_call:
@@ -49,6 +47,28 @@ on:
         type: string
         required: false
         default: "terraform,drift"
+    secrets:
+      AWS_ACCOUNT_ID:
+        description: AWS account id for the OIDC role ARN
+        required: true
+      VERCEL_API_TOKEN:
+        description: Optional TF_VAR_vercel_api_token
+        required: false
+      VERCEL_GITHUB_PAT:
+        description: Optional TF_VAR_github_pat
+        required: false
+      SANDBOX_ACCOUNT_EMAIL:
+        description: Optional TF_VAR_sandbox_account_email
+        required: false
+      DEV_ACCOUNT_EMAIL:
+        description: Optional TF_VAR_dev_account_email
+        required: false
+      NETWORK_ACCOUNT_EMAIL:
+        description: Optional TF_VAR_network_account_email
+        required: false
+      SHARED_SERVICES_ACCOUNT_EMAIL:
+        description: Optional TF_VAR_shared_services_account_email
+        required: false
     outputs:
       has_changes:
         description: Whether terraform plan reported changes
@@ -57,7 +77,7 @@ on:
         description: Whether terraform plan exited non-zero
         value: ${{ jobs.drift.outputs.has_errors }}
       plan_summary:
-        description: "Short plan summary line (e.g. Plan: 0 to add, …)"
+        description: Short plan summary line (e.g. Plan: 0 to add, 0 to change)
         value: ${{ jobs.drift.outputs.plan_summary }}
       environment_label:
         description: Echo of environment-label input


### PR DESCRIPTION
## Summary
- Cross-org callers using `secrets: inherit` got an empty `AWS_ACCOUNT_ID` (`arn:aws:iam:::role/...`)
- Declare required/optional secrets on `workflow_call` (same pattern as `gh-teams-sync`)
- Replace unicode ellipsis in `plan_summary` description with ASCII

Closes #137

## Test plan
- [ ] Merge, then update platformfuzz drift callers to pass `AWS_ACCOUNT_ID` explicitly
- [ ] `workflow_dispatch` drift on tf-aws-account-factory succeeds OIDC