### PR TITLE
fix: quote terraform-drift plan_summary description

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -77,7 +77,7 @@ on:
         description: Whether terraform plan exited non-zero
         value: ${{ jobs.drift.outputs.has_errors }}
       plan_summary:
-        description: Short plan summary line (e.g. Plan: 0 to add, 0 to change)
+        description: "Short plan summary line (e.g. Plan: 0 to add, 0 to change)"
         value: ${{ jobs.drift.outputs.plan_summary }}
       environment_label:
         description: Echo of environment-label input


### PR DESCRIPTION
## Summary
- Re-quote `plan_summary` description so `Plan:` does not break Actions YAML

Closes #141

## Test plan
- [ ] Dispatch drift on tf-aws-account-factory