### PR TITLE
fix: skip commitmsg-conform for Dependabot PRs

### DIFF
--- a/.github/workflows/commitmsg-conform.yml
+++ b/.github/workflows/commitmsg-conform.yml
@@ -40,6 +40,8 @@ on:
 
 jobs:
   conform:
+    # Dependabot commit subjects often fail conventional-commit rules; skip for bots.
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "dependabot-preview[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout code


### PR DESCRIPTION
## Summary
- Skip the reusable `commitmsg-conform` job when `github.actor` is Dependabot
- No consumer workflow changes required (`github` context is the caller's)

Closes #144

## Test plan
- [ ] CI green on this PR (human actor → job still runs)
- [ ] Open/re-run a Dependabot PR in a caller repo → `commitmsg-conform / conform` skipped