### PR TITLE
docs: add reusable workflow catalog with parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,55 @@
 # actions
 
-actionsforge Org GitHub actions
+Reusable GitHub Actions **workflows** for actionsforge (and callers in other orgs).
+
+## Quick start
+
+```yaml
+name: Markdown Lint
+
+on:
+  pull_request: {}
+
+permissions:
+  statuses: write
+  checks: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  markdown-lint:
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main
+```
+
+Full catalog, parameters, and examples: **[docs/README.md](./docs/README.md)**.
+
+## Common patterns
+
+### Required hygiene pair
+
+Most maintained repos call these on every PR:
+
+| Workflow | Doc |
+| --- | --- |
+| `markdown-lint` | [docs](./docs/workflows/markdown-lint.md) |
+| `commitmsg-conform` | [docs](./docs/workflows/commitmsg-conform.md) |
+
+### Secrets across organizations
+
+When the caller repo is **not** in `actionsforge`, do **not** rely on `secrets: inherit`.
+Declare secrets on `workflow_call` and pass them explicitly (see
+[terraform-drift](./docs/workflows/terraform-drift.md),
+[notify-slack](./docs/workflows/notify-slack.md),
+[gh-teams-sync](./docs/workflows/gh-teams-sync.md)).
+
+### Pinning
+
+```yaml
+uses: actionsforge/actions/.github/workflows/docker-image-validate.yml@main
+# or
+uses: actionsforge/actions/.github/workflows/docker-image-validate.yml@<commit-sha>
+```
+
+## Workflow index
+
+See **[docs/README.md](./docs/README.md)** for the full list grouped by category.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,93 @@
+# Reusable workflows
+
+Call from any repository:
+
+```yaml
+jobs:
+  example:
+    uses: actionsforge/actions/.github/workflows/<name>.yml@main
+    with:
+      # inputs
+    secrets:
+      # pass explicitly across organizations
+```
+
+Use `@main` for shared hygiene, or pin to a commit SHA when you need a fixed revision.
+
+Each workflow page lists **inputs**, **secrets**, **outputs**, and a minimal example.
+
+Workflows whose filenames start with `_` are internal callers for this repo and are not documented here.
+
+## Hygiene
+
+| Workflow | Summary |
+| --- | --- |
+| [`markdown-lint`](./workflows/markdown-lint.md) | Lint Markdown with markdownlint-cli |
+| [`commitmsg-conform`](./workflows/commitmsg-conform.md) | Enforce conventional commit messages (skips Dependabot) |
+| [`yaml-lint`](./workflows/yaml-lint.md) | Lint YAML with yamllint |
+| [`validate-devschema`](./workflows/validate-devschema.md) | Validate JSON (e.g. devcontainer) against a schema |
+
+## CI / language
+
+| Workflow | Summary |
+| --- | --- |
+| [`node-ci-workflow`](./workflows/node-ci-workflow.md) | Install, test, and optionally build/audit a Node project |
+| [`python-lint-test`](./workflows/python-lint-test.md) | Install, lint, and test a Python project |
+| [`python-image-validate`](./workflows/python-image-validate.md) | Python lint/test plus Docker image validate |
+| [`go-mod-tidy-build`](./workflows/go-mod-tidy-build.md) | go mod tidy check and build |
+| [`go-binary-release`](./workflows/go-binary-release.md) | Cross-compile Go binaries and attach to a GitHub Release |
+
+## Docker
+
+| Workflow | Summary |
+| --- | --- |
+| [`docker-image-validate`](./workflows/docker-image-validate.md) | Build a Docker image and optionally scan with Trivy |
+| [`docker-image-publish`](./workflows/docker-image-publish.md) | Build/push to GHCR or ECR (optional Trivy) |
+| [`docker-image-release`](./workflows/docker-image-release.md) | Build/push GHCR tags and optionally create a GitHub Release |
+
+## Terraform
+
+| Workflow | Summary |
+| --- | --- |
+| [`terraform-lint-validate`](./workflows/terraform-lint-validate.md) | terraform fmt/validate (and related checks) |
+| [`terraform-docs`](./workflows/terraform-docs.md) | Render terraform-docs into README and push on PRs |
+| [`terraform-tag`](./workflows/terraform-tag.md) | Create a Terraform module semver tag (and optional release) |
+| [`terraform-tag-and-release`](./workflows/terraform-tag-and-release.md) | Thin caller around terraform-tag with release enabled |
+| [`terraform-drift`](./workflows/terraform-drift.md) | Scheduled terraform plan; open an issue (and outputs) on drift |
+
+## Helm
+
+| Workflow | Summary |
+| --- | --- |
+| [`chart-lint-validate`](./workflows/chart-lint-validate.md) | Helm chart-testing lint/install |
+| [`chart-releaser`](./workflows/chart-releaser.md) | Package and release Helm charts with chart-releaser |
+
+## Pages / sites
+
+| Workflow | Summary |
+| --- | --- |
+| [`github-pages-deploy`](./workflows/github-pages-deploy.md) | Upload static files and deploy to GitHub Pages |
+| [`astro-pages-deploy`](./workflows/astro-pages-deploy.md) | Build an Astro site and deploy to GitHub Pages |
+| [`jekyll-pages-deploy`](./workflows/jekyll-pages-deploy.md) | Build a Jekyll site and deploy to GitHub Pages |
+
+## Node actions
+
+| Workflow | Summary |
+| --- | --- |
+| [`node-action-tag-and-release`](./workflows/node-action-tag-and-release.md) | Semver tag + release for Node-based GitHub Actions |
+
+## Repo automation
+
+| Workflow | Summary |
+| --- | --- |
+| [`auto-assign-issue`](./workflows/auto-assign-issue.md) | Auto-assign new issues |
+| [`dependabot-auto-merge`](./workflows/dependabot-auto-merge.md) | Enable GitHub auto-merge for Dependabot PRs |
+| [`gh-teams-sync`](./workflows/gh-teams-sync.md) | Sync org teams from a YAML file |
+
+## Notify / secrets
+
+| Workflow | Summary |
+| --- | --- |
+| [`notify-slack`](./workflows/notify-slack.md) | Post a Slack message via webhook (GitHub secret or Bitwarden) |
+| [`bitwarden-get-secret`](./workflows/bitwarden-get-secret.md) | Fetch one Bitwarden SM secret into a job output |
+

--- a/docs/workflows/astro-pages-deploy.md
+++ b/docs/workflows/astro-pages-deploy.md
@@ -1,0 +1,28 @@
+# `astro-pages-deploy`
+
+Build an Astro site and deploy to GitHub Pages.
+
+## Call
+
+`actionsforge/actions/.github/workflows/astro-pages-deploy.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/astro-pages-deploy.yml@main
+    with:
+      node-version: 22
+      path: .
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `node-version` | `string` | no | `22` | Node.js version for the Astro build |
+| `path` | `string` | no | `.` | Path to the Astro project root |
+| `validate-command` | `string` | no | `(empty)` | Optional command after npm ci (e.g. npm run validate) |
+| `test-command` | `string` | no | `(empty)` | Optional command after npm ci (e.g. npm run test) |
+

--- a/docs/workflows/auto-assign-issue.md
+++ b/docs/workflows/auto-assign-issue.md
@@ -1,0 +1,32 @@
+# `auto-assign-issue`
+
+Auto-assign new issues.
+
+## Call
+
+`actionsforge/actions/.github/workflows/auto-assign-issue.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/auto-assign-issue.yml@main
+    with:
+      assignees: jajera
+      numOfAssignee: 5
+      abortIfPreviousAssignees: false
+      removePreviousAssignees: false
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `assignees` | `string` | no | `jajera` | Comma separated list of user names. Issue will be assigned to those users. |
+| `numOfAssignee` | `number` | no | `5` | Number of assignees that will be randomly picked from the teams or assignees. |
+| `abortIfPreviousAssignees` | `boolean` | no | `false` | Flag that aborts the action if there were assignees previously. |
+| `removePreviousAssignees` | `boolean` | no | `false` | Flag that removes assignees before assigning them (useful the issue is reasigned). |
+| `allowNoAssignees` | `boolean` | no | `false` | Flag that prevents the action from failing when there are no assignees. |
+| `allowSelfAssign` | `boolean` | no | `true` | Flag that allows self-assignment to the issue author. |
+

--- a/docs/workflows/bitwarden-get-secret.md
+++ b/docs/workflows/bitwarden-get-secret.md
@@ -1,0 +1,38 @@
+# `bitwarden-get-secret`
+
+Fetch one Bitwarden SM secret into a job output.
+
+## Call
+
+`actionsforge/actions/.github/workflows/bitwarden-get-secret.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/bitwarden-get-secret.yml@main
+    with:
+      secret-id-secret: BW_SECRET_ID
+      env-name: SECRET_VALUE
+      base-url: "https://vault.bitwarden.com"
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `secret-id-secret` | `string` | no | `BW_SECRET_ID` | GitHub secret name that holds the Bitwarden secret UUID |
+| `env-name` | `string` | no | `SECRET_VALUE` | Name used when exporting the fetched value from sm-action |
+| `base-url` | `string` | no | `https://vault.bitwarden.com` | Bitwarden Secrets Manager API base URL |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `value` | Fetched secret value (masked) |
+
+## Notes
+
+- Uses caller secrets: `BW_ACCESS_TOKEN` and a secret named by `secret-id-secret` (default `BW_SECRET_ID`).
+

--- a/docs/workflows/chart-lint-validate.md
+++ b/docs/workflows/chart-lint-validate.md
@@ -1,0 +1,32 @@
+# `chart-lint-validate`
+
+Helm chart-testing lint/install.
+
+## Call
+
+`actionsforge/actions/.github/workflows/chart-lint-validate.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/chart-lint-validate.yml@main
+    with:
+      chart_dirs: charts
+      target_branch: ""
+      helm_version: latest
+      python_version: 3.x
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `chart_dirs` | `string` | no | `charts` | Chart directory relative to repository root (passed to ct --chart-dirs) |
+| `target_branch` | `string` | no | `(empty)` | Target branch for chart-testing (defaults to repository default branch) |
+| `helm_version` | `string` | no | `latest` | Helm version (e.g., 3.15.4 or latest) |
+| `python_version` | `string` | no | `3.x` | Python version for chart-testing |
+| `run_lint` | `boolean` | no | `true` | Run chart lint validation |
+| `run_install` | `boolean` | no | `true` | Run chart install validation |
+

--- a/docs/workflows/chart-releaser.md
+++ b/docs/workflows/chart-releaser.md
@@ -1,0 +1,34 @@
+# `chart-releaser`
+
+Package and release Helm charts with chart-releaser.
+
+## Call
+
+`actionsforge/actions/.github/workflows/chart-releaser.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/chart-releaser.yml@main
+    with:
+      charts_dir: charts
+    secrets:
+      cr_token: ${{ secrets.cr_token }}
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `charts_dir` | `string` | no | `charts` | Directory containing Helm charts (e.g., 'charts' or '.') |
+
+## Secrets
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `cr_token` | yes |  |
+
+Pass secrets **explicitly** when the caller and this repo are in different orgs (`secrets: inherit` does not cross organizations).
+

--- a/docs/workflows/commitmsg-conform.md
+++ b/docs/workflows/commitmsg-conform.md
@@ -1,0 +1,28 @@
+# `commitmsg-conform`
+
+Enforce conventional commit messages (skips Dependabot).
+
+## Call
+
+`actionsforge/actions/.github/workflows/commitmsg-conform.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/commitmsg-conform.yml@main
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `config` | `string` | no | see workflow default | Inline Conform YAML used when the caller has no `.conform.yaml` |
+
+## Notes
+
+- Skips when `github.actor` is Dependabot (`dependabot[bot]` / `dependabot-preview[bot]`).
+- Default policy requires a conventional commit **body** (blank line + description).
+- If the caller repo already has `.conform.yaml`, that file is used and the `config` input is ignored.
+

--- a/docs/workflows/dependabot-auto-merge.md
+++ b/docs/workflows/dependabot-auto-merge.md
@@ -1,0 +1,37 @@
+# `dependabot-auto-merge`
+
+Enable GitHub auto-merge for Dependabot PRs.
+
+## Call
+
+`actionsforge/actions/.github/workflows/dependabot-auto-merge.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/dependabot-auto-merge.yml@main
+    with:
+      target: any
+      merge-method: squash
+      use-github-auto-merge: true
+      skip-verification: false
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `target` | `string` | no | `any` | SemVer auto-merge ceiling (major, minor, patch, any) |
+| `merge-method` | `string` | no | `squash` | Merge method (squash, merge, rebase) |
+| `use-github-auto-merge` | `boolean` | no | `true` | Enable GitHub auto-merge instead of merging immediately |
+| `skip-verification` | `boolean` | no | `false` | Skip Dependabot user/commit verification (unused; kept for callers) |
+| `approve-only` | `boolean` | no | `false` | Only approve the PR without merging (unsupported without Actions approve permission) |
+| `exclude` | `string` | no | `(empty)` | Comma-separated packages to exclude from auto-merge |
+
+## Notes
+
+- Enable **Allow auto-merge** on the repo and configure branch protection/rulesets for `gh pr merge --auto`.
+- PRs that change workflow files may fail to merge with `GITHUB_TOKEN` (needs `workflows` permission).
+

--- a/docs/workflows/docker-image-publish.md
+++ b/docs/workflows/docker-image-publish.md
@@ -1,0 +1,43 @@
+# `docker-image-publish`
+
+Build/push to GHCR or ECR (optional Trivy).
+
+## Call
+
+`actionsforge/actions/.github/workflows/docker-image-publish.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/docker-image-publish.yml@main
+    with:
+      registry-type: ghcr
+      dockerfile: Dockerfile
+      context: .
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `registry-type` | `string` | no | `ghcr` | Container registry target (ghcr or ecr) |
+| `image-name` | `string` | no | `(empty)` | Image name without registry (defaults to github.repository) |
+| `dockerfile` | `string` | no | `Dockerfile` | Path to the Dockerfile |
+| `context` | `string` | no | `.` | Docker build context |
+| `platforms` | `string` | no | `linux/amd64` | Target platforms for the build |
+| `aws-region` | `string` | no | `ap-southeast-2` | AWS region for ECR (registry-type=ecr only) |
+| `ecr-repository` | `string` | no | `(empty)` | ECR repository name (registry-type=ecr only) |
+| `scan-enabled` | `boolean` | no | `true` | Run Trivy before push |
+| `trivy-severity` | `string` | no | `CRITICAL` | Comma-separated severities that fail the scan |
+| `trivy-ignore-unfixed` | `boolean` | no | `false` | Ignore unfixed vulnerabilities in Trivy |
+
+## Secrets
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `aws-role-arn` | no | IAM role ARN for OIDC ECR push (registry-type=ecr only) |
+
+Pass secrets **explicitly** when the caller and this repo are in different orgs (`secrets: inherit` does not cross organizations).
+

--- a/docs/workflows/docker-image-release.md
+++ b/docs/workflows/docker-image-release.md
@@ -1,0 +1,38 @@
+# `docker-image-release`
+
+Build/push GHCR tags and optionally create a GitHub Release.
+
+## Overview
+
+- Build/push a GHCR image (semver + sha + latest) and create a GitHub Release on tags.
+- Distinct from docker-image-publish (scan/ECR-focused): this matches platformfuzz
+- *-image build-and-release.yml (push + softprops GH release, no Trivy).
+
+## Call
+
+`actionsforge/actions/.github/workflows/docker-image-release.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/docker-image-release.yml@main
+    with:
+      dockerfile: Dockerfile
+      context: .
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `image-name` | `string` | no | `(empty)` | Image name without registry (defaults to github.repository) |
+| `image-suffix` | `string` | no | `(empty)` | Optional suffix appended to the image name (e.g. -test) |
+| `dockerfile` | `string` | no | `Dockerfile` | Path to the Dockerfile |
+| `context` | `string` | no | `.` | Docker build context |
+| `build-args` | `string` | no | `(empty)` | Docker build-args (multiline KEY=value), optional |
+| `platforms` | `string` | no | `linux/amd64` | Target platforms for the build |
+| `create-release` | `boolean` | no | `true` | Create a GitHub Release when the ref is a tag |
+| `generate-release-notes` | `boolean` | no | `true` | Autogenerate GitHub Release notes |
+

--- a/docs/workflows/docker-image-validate.md
+++ b/docs/workflows/docker-image-validate.md
@@ -1,0 +1,35 @@
+# `docker-image-validate`
+
+Build a Docker image and optionally scan with Trivy.
+
+## Call
+
+`actionsforge/actions/.github/workflows/docker-image-validate.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/docker-image-validate.yml@main
+    with:
+      image-tag: "image:validate"
+      dockerfile: Dockerfile
+      context: .
+      platforms: linux/amd64
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `image-tag` | `string` | no | `image:validate` | Local tag for the built image |
+| `dockerfile` | `string` | no | `Dockerfile` | Path to the Dockerfile |
+| `context` | `string` | no | `.` | Docker build context |
+| `platforms` | `string` | no | `linux/amd64` | Target platforms for the build |
+| `scan-enabled` | `boolean` | no | `true` | Run Trivy vulnerability scan on the built image |
+| `trivy-severity` | `string` | no | `CRITICAL,HIGH` | Comma-separated severities to report |
+| `trivy-exit-code` | `string` | no | `1` | Exit code when vulnerabilities are found at or above trivy-severity |
+| `trivy-ignore-unfixed` | `boolean` | no | `false` | Ignore unfixed vulnerabilities in Trivy |
+| `trivy-vuln-type` | `string` | no | `os,library` | Comma-separated vulnerability types for Trivy (os, library) |
+

--- a/docs/workflows/gh-teams-sync.md
+++ b/docs/workflows/gh-teams-sync.md
@@ -1,0 +1,42 @@
+# `gh-teams-sync`
+
+Sync org teams from a YAML file.
+
+## Overview
+
+- Sync GitHub org teams from a declarative YAML file via
+- actionsforge/actions-gh-teams-sync. Callers must pass GH_ORG_TOKEN
+- explicitly (secrets: inherit is unreliable across organizations).
+
+## Call
+
+`actionsforge/actions/.github/workflows/gh-teams-sync.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/gh-teams-sync.yml@main
+    with:
+      config-path: teams.yaml
+      dry-run: false
+    secrets:
+      GH_ORG_TOKEN: ${{ secrets.GH_ORG_TOKEN }}
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `config-path` | `string` | no | `teams.yaml` | Path to the teams YAML config |
+| `dry-run` | `boolean` | no | `false` | Run without making changes |
+
+## Secrets
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `GH_ORG_TOKEN` | yes | PAT with admin:org (and repo) for team membership sync |
+
+Pass secrets **explicitly** when the caller and this repo are in different orgs (`secrets: inherit` does not cross organizations).
+

--- a/docs/workflows/github-pages-deploy.md
+++ b/docs/workflows/github-pages-deploy.md
@@ -1,0 +1,28 @@
+# `github-pages-deploy`
+
+Upload static files and deploy to GitHub Pages.
+
+## Call
+
+`actionsforge/actions/.github/workflows/github-pages-deploy.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/github-pages-deploy.yml@main
+    with:
+      path: .
+      artifact-name: github-pages
+      retention-days: 1
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `path` | `string` | no | `.` | Path to the directory of static files to publish |
+| `artifact-name` | `string` | no | `github-pages` | Name of the Pages artifact to upload and deploy |
+| `retention-days` | `string` | no | `1` | Number of days to retain the uploaded artifact |
+

--- a/docs/workflows/go-binary-release.md
+++ b/docs/workflows/go-binary-release.md
@@ -1,0 +1,43 @@
+# `go-binary-release`
+
+Cross-compile Go binaries and attach to a GitHub Release.
+
+## Overview
+
+- Cross-compile Go binaries for configured GOOS/GOARCH pairs and publish
+- them as GitHub Release assets (typically on version tags).
+
+## Call
+
+`actionsforge/actions/.github/workflows/go-binary-release.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/go-binary-release.yml@main
+    with:
+      binary-name: <value>
+      go-version: stable
+      working-directory: .
+      package: .
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `go-version` | `string` | no | `stable` | Go version for setup-go (e.g. 1.25, stable) |
+| `working-directory` | `string` | no | `.` | Directory containing go.mod |
+| `binary-name` | `string` | yes | — | Base name for release artifacts (name-goos-goarch) |
+| `package` | `string` | no | `.` | Package or main file passed to go build |
+| `ldflags` | `string` | no | `-s -w` | Linker flags passed to go build -ldflags |
+| `platforms` | `string` | no | see workflow default | Newline-separated GOOS/GOARCH pairs |
+| `dist-dir` | `string` | no | `dist` | Output directory for built binaries |
+| `create-release` | `boolean` | no | `true` | Create or update a GitHub Release and upload assets |
+| `generate-release-notes` | `boolean` | no | `true` | Autogenerate GitHub Release notes |
+| `draft` | `boolean` | no | `false` | Create the release as a draft |
+| `prerelease` | `boolean` | no | `false` | Mark the release as a prerelease |
+| `cache` | `boolean` | no | `true` | Enable setup-go module cache |
+

--- a/docs/workflows/go-mod-tidy-build.md
+++ b/docs/workflows/go-mod-tidy-build.md
@@ -1,0 +1,37 @@
+# `go-mod-tidy-build`
+
+go mod tidy check and build.
+
+## Overview
+
+- Verify go.mod/go.sum are tidy and optionally compile packages.
+- Intended for Go service/CLI CI before image build or release.
+
+## Call
+
+`actionsforge/actions/.github/workflows/go-mod-tidy-build.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/go-mod-tidy-build.yml@main
+    with:
+      go-version: stable
+      working-directory: .
+      tidy: true
+      build: true
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `go-version` | `string` | no | `stable` | Go version for setup-go (e.g. 1.25, stable) |
+| `working-directory` | `string` | no | `.` | Directory containing go.mod |
+| `tidy` | `boolean` | no | `true` | Run go mod tidy and fail if go.mod/go.sum change |
+| `build` | `boolean` | no | `true` | Run a go build after tidy |
+| `build-command` | `string` | no | `go build -v ./...` | Build command (used when build is true) |
+| `cache` | `boolean` | no | `true` | Enable setup-go module cache |
+

--- a/docs/workflows/jekyll-pages-deploy.md
+++ b/docs/workflows/jekyll-pages-deploy.md
@@ -1,0 +1,30 @@
+# `jekyll-pages-deploy`
+
+Build a Jekyll site and deploy to GitHub Pages.
+
+## Call
+
+`actionsforge/actions/.github/workflows/jekyll-pages-deploy.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/jekyll-pages-deploy.yml@main
+    with:
+      source: ./
+      destination: ./_site
+      artifact-name: github-pages
+      retention-days: 1
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `source` | `string` | no | `./` | Directory where the Jekyll source files reside |
+| `destination` | `string` | no | `./_site` | Jekyll build output directory (uploaded as the Pages artifact) |
+| `artifact-name` | `string` | no | `github-pages` | Name of the Pages artifact to upload and deploy |
+| `retention-days` | `string` | no | `1` | Number of days to retain the uploaded artifact |
+

--- a/docs/workflows/markdown-lint.md
+++ b/docs/workflows/markdown-lint.md
@@ -1,0 +1,27 @@
+# `markdown-lint`
+
+Lint Markdown with markdownlint-cli.
+
+## Call
+
+`actionsforge/actions/.github/workflows/markdown-lint.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main
+    with:
+      ignore: node_modules
+      node-version: 20
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `config` | `string` | no | see workflow default | a markdownlint compatible JSON object string  |
+| `ignore` | `string` | no | `node_modules` | a space separated list of directories and files to ignore  |
+| `node-version` | `string` | no | `20` | Node.js version used to install markdownlint-cli |
+

--- a/docs/workflows/node-action-tag-and-release.md
+++ b/docs/workflows/node-action-tag-and-release.md
@@ -1,0 +1,37 @@
+# `node-action-tag-and-release`
+
+Semver tag + release for Node-based GitHub Actions.
+
+## Overview
+
+- Semver tag + GitHub Release for Node/JS GitHub Actions.
+- Bumps patch (with minor/major rollover at .99), force-updates floating vMAJOR,
+- and optionally builds + commits dist/ before tagging.
+
+## Call
+
+`actionsforge/actions/.github/workflows/node-action-tag-and-release.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/node-action-tag-and-release.yml@main
+    with:
+      node-version: 20
+      build: true
+      commit-dist: false
+      create-release: true
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `node-version` | `string` | no | `20` | Node.js version |
+| `build` | `boolean` | no | `true` | Run npm run build after install |
+| `commit-dist` | `boolean` | no | `false` | Commit and push dist/ changes before tagging |
+| `create-release` | `boolean` | no | `true` | Create a GitHub Release for the new tag |
+| `update-major-tag` | `boolean` | no | `true` | Force-update floating vMAJOR tag to the new release |
+

--- a/docs/workflows/node-ci-workflow.md
+++ b/docs/workflows/node-ci-workflow.md
@@ -1,0 +1,43 @@
+# `node-ci-workflow`
+
+Install, test, and optionally build/audit a Node project.
+
+## Overview
+
+- Generic Node.js CI: install → optional typecheck → test → optional build → optional audit.
+- Repo-specific test env (tokens, users, etc.) belongs in the project's test setup
+- (e.g. vitest setupFiles / jest setupFiles), not in this reusable.
+
+## Call
+
+`actionsforge/actions/.github/workflows/node-ci-workflow.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/node-ci-workflow.yml@main
+    with:
+      node-version: 20
+      working-directory: .
+      install-command: npm ci --no-audit --no-fund
+      typecheck: false
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `node-version` | `string` | no | `20` | Node.js version |
+| `working-directory` | `string` | no | `.` | Directory containing package.json / lockfile |
+| `install-command` | `string` | no | `npm ci --no-audit --no-fund` | Shell command to install dependencies |
+| `typecheck` | `boolean` | no | `false` | Run npm run typecheck before tests |
+| `typecheck-command` | `string` | no | `npm run typecheck` | Typecheck command (used when typecheck is true) |
+| `test-command` | `string` | no | `npm test` | Test command (coverage flag appended when coverage is true) |
+| `coverage` | `boolean` | no | `false` | Append --coverage to test-command |
+| `build` | `boolean` | no | `true` | Run build after tests |
+| `build-command` | `string` | no | `npm run build` | Build command (used when build is true) |
+| `audit` | `boolean` | no | `false` | Run npm audit --audit-level=high after build |
+| `audit-command` | `string` | no | `npm audit --audit-level=high` | Audit command (used when audit is true) |
+

--- a/docs/workflows/notify-slack.md
+++ b/docs/workflows/notify-slack.md
@@ -1,0 +1,50 @@
+# `notify-slack`
+
+Post a Slack message via webhook (GitHub secret or Bitwarden).
+
+## Call
+
+`actionsforge/actions/.github/workflows/notify-slack.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/notify-slack.yml@main
+    with:
+      title: <value>
+      text: <value>
+      webhook-source: github
+      include-run-link: true
+      fail-on-error: false
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `title` | `string` | yes | — | Slack message header |
+| `text` | `string` | yes | — | Primary message body (mrkdwn-friendly plain text) |
+| `webhook-source` | `string` | no | `github` | Where to load the webhook URL from (github or bitwarden) |
+| `include-run-link` | `boolean` | no | `true` | Include a button linking to the triggering workflow run |
+| `fail-on-error` | `boolean` | no | `false` | Fail the job if Slack delivery fails |
+| `bitwarden-base-url` | `string` | no | `https://vault.bitwarden.com` | Bitwarden Secrets Manager API base URL |
+
+## Secrets
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `SLACK_WEBHOOK_URL` | no | Incoming webhook URL (webhook-source=github) |
+| `BW_ACCESS_TOKEN` | no | Bitwarden SM access token (webhook-source=bitwarden) |
+| `BW_SLACK_WEBHOOK_SECRET_ID` | no | Bitwarden secret id for the Slack webhook URL |
+
+Pass secrets **explicitly** when the caller and this repo are in different orgs (`secrets: inherit` does not cross organizations).
+
+## Notes
+
+- Prefer passing the webhook as an explicit secret when calling from another org.
+

--- a/docs/workflows/python-image-validate.md
+++ b/docs/workflows/python-image-validate.md
@@ -1,0 +1,36 @@
+# `python-image-validate`
+
+Python lint/test plus Docker image validate.
+
+## Call
+
+`actionsforge/actions/.github/workflows/python-image-validate.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/python-image-validate.yml@main
+    with:
+      python-version: 3.13
+      working-directory: .
+      test-command: pytest tests/ -v
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `python-version` | `string` | no | `3.13` | Python version for lint and test |
+| `working-directory` | `string` | no | `.` | Directory containing pyproject.toml |
+| `install-command` | `string` | no | see workflow default | Shell command to install Python dependencies |
+| `lint-command` | `string` | no | `(empty)` | Optional lint command (skipped when empty) |
+| `test-command` | `string` | no | `pytest tests/ -v` | Shell command to run the test suite |
+| `image-tag` | `string` | no | `image:validate` | Local tag for the Docker validate build |
+| `dockerfile` | `string` | no | `Dockerfile` | Path to the Dockerfile |
+| `docker-context` | `string` | no | `.` | Docker build context |
+| `docker-platforms` | `string` | no | `linux/amd64` | Target platforms for the Docker validate build |
+| `docker-validate-enabled` | `boolean` | no | `true` | Build and scan the Docker image during PR checks |
+| `trivy-vuln-type` | `string` | no | `os,library` | Comma-separated vulnerability types for Trivy (os, library) |
+

--- a/docs/workflows/python-lint-test.md
+++ b/docs/workflows/python-lint-test.md
@@ -1,0 +1,30 @@
+# `python-lint-test`
+
+Install, lint, and test a Python project.
+
+## Call
+
+`actionsforge/actions/.github/workflows/python-lint-test.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/python-lint-test.yml@main
+    with:
+      python-version: 3.13
+      working-directory: .
+      test-command: pytest tests/ -v
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `python-version` | `string` | no | `3.13` | Python version for lint and test |
+| `working-directory` | `string` | no | `.` | Directory containing pyproject.toml |
+| `install-command` | `string` | no | see workflow default | Shell command to install dependencies |
+| `lint-command` | `string` | no | `(empty)` | Optional lint command (skipped when empty) |
+| `test-command` | `string` | no | `pytest tests/ -v` | Shell command to run the test suite |
+

--- a/docs/workflows/terraform-docs.md
+++ b/docs/workflows/terraform-docs.md
@@ -1,0 +1,20 @@
+# `terraform-docs`
+
+Render terraform-docs into README and push on PRs.
+
+## Call
+
+`actionsforge/actions/.github/workflows/terraform-docs.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/terraform-docs.yml@main
+```
+
+## Inputs
+
+None.
+

--- a/docs/workflows/terraform-drift.md
+++ b/docs/workflows/terraform-drift.md
@@ -1,0 +1,72 @@
+# `terraform-drift`
+
+Scheduled terraform plan; open an issue (and outputs) on drift.
+
+## Call
+
+`actionsforge/actions/.github/workflows/terraform-drift.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/terraform-drift.yml@main
+    with:
+      working-directory: .
+      environment-label: prod
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      # VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}  # optional TF_VAR
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `working-directory` | `string` | no | `.` | Path to the Terraform configuration directory |
+| `environment-label` | `string` | no | `(empty)` | Optional label included in the drift issue title (e.g. env name) |
+| `aws-region` | `string` | no | `(empty)` | AWS region for OIDC (defaults to vars.AWS_REGION) |
+| `terraform-version` | `string` | no | `(empty)` | Terraform version (defaults to vars.TERRAFORM_VERSION) |
+| `init-upgrade` | `boolean` | no | `false` | Run terraform init -upgrade |
+| `create-issue` | `boolean` | no | `true` | Open a GitHub issue when drift is detected |
+| `issue-labels` | `string` | no | `terraform,drift` | Comma-separated labels for the drift issue |
+
+## Secrets
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `AWS_ACCOUNT_ID` | yes | AWS account id for the OIDC role ARN |
+| `VERCEL_API_TOKEN` | no | Optional TF_VAR_vercel_api_token |
+| `VERCEL_GITHUB_PAT` | no | Optional TF_VAR_github_pat |
+| `SANDBOX_ACCOUNT_EMAIL` | no | Optional TF_VAR_sandbox_account_email |
+| `DEV_ACCOUNT_EMAIL` | no | Optional TF_VAR_dev_account_email |
+| `NETWORK_ACCOUNT_EMAIL` | no | Optional TF_VAR_network_account_email |
+| `SHARED_SERVICES_ACCOUNT_EMAIL` | no | Optional TF_VAR_shared_services_account_email |
+
+Pass secrets **explicitly** when the caller and this repo are in different orgs (`secrets: inherit` does not cross organizations).
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `has_changes` | Whether terraform plan reported changes |
+| `has_errors` | Whether terraform plan exited non-zero |
+| `plan_summary` | Short plan summary line (e.g. Plan: 0 to add, 0 to change) |
+| `environment_label` | Echo of environment-label input |
+
+## Notes
+
+- Pass secrets **explicitly** (do not use `secrets: inherit` across orgs).
+- Only `AWS_ACCOUNT_ID` is required; other secrets are optional `TF_VAR_*` pass-through.
+- For Slack, call [`notify-slack`](./notify-slack.md) when `outputs.has_changes == 'true'`.
+- Caller variables: `OIDC_ROLE_NAME`, `AWS_REGION`, `TERRAFORM_VERSION`.
+
+## Expected caller variables
+
+| Variable | Purpose |
+| --- | --- |
+| `OIDC_ROLE_NAME` | IAM role name used in the OIDC assume-role ARN |
+| `AWS_REGION` | Used when `aws-region` input is empty |
+| `TERRAFORM_VERSION` | Used when `terraform-version` input is empty |
+

--- a/docs/workflows/terraform-lint-validate.md
+++ b/docs/workflows/terraform-lint-validate.md
@@ -1,0 +1,24 @@
+# `terraform-lint-validate`
+
+terraform fmt/validate (and related checks).
+
+## Call
+
+`actionsforge/actions/.github/workflows/terraform-lint-validate.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/terraform-lint-validate.yml@main
+    with:
+      path: .
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `path` | `string` | no | `.` | Path to the Terraform configuration directory |
+

--- a/docs/workflows/terraform-tag-and-release.md
+++ b/docs/workflows/terraform-tag-and-release.md
@@ -1,0 +1,20 @@
+# `terraform-tag-and-release`
+
+Thin caller around terraform-tag with release enabled.
+
+## Call
+
+`actionsforge/actions/.github/workflows/terraform-tag-and-release.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/terraform-tag-and-release.yml@main
+```
+
+## Inputs
+
+None.
+

--- a/docs/workflows/terraform-tag.md
+++ b/docs/workflows/terraform-tag.md
@@ -1,0 +1,24 @@
+# `terraform-tag`
+
+Create a Terraform module semver tag (and optional release).
+
+## Call
+
+`actionsforge/actions/.github/workflows/terraform-tag.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/terraform-tag.yml@main
+    with:
+      create-release: false
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `create-release` | `boolean` | no | `false` | Create a GitHub Release for the new tag |
+

--- a/docs/workflows/validate-devschema.md
+++ b/docs/workflows/validate-devschema.md
@@ -1,0 +1,29 @@
+# `validate-devschema`
+
+Validate JSON (e.g. devcontainer) against a schema.
+
+## Call
+
+`actionsforge/actions/.github/workflows/validate-devschema.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/validate-devschema.yml@main
+    with:
+      data: .devcontainer/devcontainer.json
+      verbose: false
+      python-version: 3.13
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `schema` | `string` | no | see workflow default | Path or URL to the JSON schema. |
+| `data` | `string` | no | `.devcontainer/devcontainer.json` | Path or URL to the JSON data. |
+| `verbose` | `boolean` | no | `false` | Enable verbose output. |
+| `python-version` | `string` | no | `3.13` | Python version to use. Must be one of: 3.9, 3.10, 3.11, 3.12, 3.13  |
+

--- a/docs/workflows/yaml-lint.md
+++ b/docs/workflows/yaml-lint.md
@@ -1,0 +1,30 @@
+# `yaml-lint`
+
+Lint YAML with yamllint.
+
+## Call
+
+`actionsforge/actions/.github/workflows/yaml-lint.yml@main`
+
+## Example
+
+```yaml
+jobs:
+  call:
+    uses: actionsforge/actions/.github/workflows/yaml-lint.yml@main
+    with:
+      yamllint_file_or_dir: .
+      yamllint_config_filepath: .yamllint
+      yamllint_format: github
+      yamllint_strict: false
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `yamllint_file_or_dir` | `string` | no | `.` | File or directory to lint (defaults to repository root) |
+| `yamllint_config_filepath` | `string` | no | `.yamllint` | Path to yamllint configuration file |
+| `yamllint_format` | `string` | no | `github` | Output format for yamllint (github, standard, etc.) |
+| `yamllint_strict` | `boolean` | no | `false` | Enable strict mode for yamllint |
+


### PR DESCRIPTION
## Summary
- Replace the stub root README with a short quick-start and common patterns
- Add `docs/README.md` index grouped by category
- Document all 28 public reusable workflows with call path, example, inputs, secrets, and outputs

Closes #146

## Test plan
- [ ] Spot-check a few workflow pages against `.github/workflows/*.yml` inputs/secrets
- [ ] Confirm markdown-lint and commitmsg-conform pass on this PR