### PR TITLE
feat: add pr-safe deploy and bundler build to jekyll-pages

### DIFF
--- a/.github/workflows/jekyll-pages-deploy.yml
+++ b/.github/workflows/jekyll-pages-deploy.yml
@@ -23,6 +23,18 @@ on:
         type: string
         required: false
         default: "1"
+      deploy:
+        description: Deploy the built site to GitHub Pages (also skipped on pull_request)
+        type: boolean
+        required: false
+        default: true
+      ruby-version:
+        description: >
+          Ruby version for a Gemfile/bundler build (ruby/setup-ruby).
+          Leave empty to use actions/jekyll-build-pages instead.
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -41,9 +53,26 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d #v6.0.0
 
-      - name: Build with Jekyll
+      - name: Set up Ruby
+        if: inputs.ruby-version != ''
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b #v1.321.0
+        with:
+          ruby-version: ${{ inputs.ruby-version }}
+          bundler-cache: true
+          working-directory: ${{ inputs.source }}
+
+      - name: Build with Bundler
+        if: inputs.ruby-version != ''
+        working-directory: ${{ inputs.source }}
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+
+      - name: Build with Jekyll Pages
+        if: inputs.ruby-version == ''
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 #v1.0.13
         with:
           source: ${{ inputs.source }}
@@ -58,6 +87,7 @@ jobs:
 
   deploy:
     needs: build
+    if: ${{ inputs.deploy && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/docs/workflows/jekyll-pages-deploy.md
+++ b/docs/workflows/jekyll-pages-deploy.md
@@ -9,14 +9,22 @@ Build a Jekyll site and deploy to GitHub Pages.
 ## Example
 
 ```yaml
+# Build on PRs; deploy only on push / workflow_dispatch
 jobs:
-  call:
+  pages:
     uses: actionsforge/actions/.github/workflows/jekyll-pages-deploy.yml@main
     with:
-      source: ./
-      destination: ./_site
-      artifact-name: github-pages
-      retention-days: 1
+      source: docs
+      destination: docs/_site
+      ruby-version: "3.3"
+```
+
+For a default GitHub Pages / `jekyll-build-pages` site (no custom Gemfile Ruby):
+
+```yaml
+jobs:
+  pages:
+    uses: actionsforge/actions/.github/workflows/jekyll-pages-deploy.yml@main
 ```
 
 ## Inputs
@@ -27,4 +35,11 @@ jobs:
 | `destination` | `string` | no | `./_site` | Jekyll build output directory (uploaded as the Pages artifact) |
 | `artifact-name` | `string` | no | `github-pages` | Name of the Pages artifact to upload and deploy |
 | `retention-days` | `string` | no | `1` | Number of days to retain the uploaded artifact |
+| `deploy` | `boolean` | no | `true` | Deploy to GitHub Pages (also skipped on `pull_request`) |
+| `ruby-version` | `string` | no | `(empty)` | Ruby for Gemfile/bundler build; empty uses `actions/jekyll-build-pages` |
 
+## Notes
+
+- On `pull_request`, the build still runs and uploads an artifact; deploy is skipped unless you somehow call outside a PR (and `deploy` is `true`).
+- Set `ruby-version` (e.g. `3.3`) for sites with a custom `Gemfile` (just-the-docs, Jekyll 4.x, etc.).
+- Leave `ruby-version` empty to keep the GitHub Pages–compatible `jekyll-build-pages` builder.


### PR DESCRIPTION
## Summary
- Skip Pages deploy on `pull_request` (and when `deploy: false`)
- Optional `ruby-version` enables Gemfile/bundler builds for custom Jekyll sites
- Empty `ruby-version` keeps existing `jekyll-build-pages` behavior

Closes #148

## Test plan
- [ ] Existing jajera/jekyll caller still works with defaults
- [ ] privatelink-conduit can call with `source: docs`, `destination: docs/_site`, `ruby-version: "3.3"`
- [ ] Hygiene checks pass