### PR TITLE
feat: add reusable Gatekeeper validate workflow

### DIFF
--- a/.github/workflows/_gatekeeper-validate.yml
+++ b/.github/workflows/_gatekeeper-validate.yml
@@ -1,0 +1,22 @@
+# Internal smoke: call gatekeeper-validate against fixtures (no external policy repo).
+name: _gatekeeper-validate
+
+on:
+  pull_request:
+    paths:
+      - "scripts/gatekeeper/**"
+      - "fixtures/gatekeeper/**"
+      - ".github/workflows/gatekeeper-validate.yml"
+      - ".github/workflows/_gatekeeper-validate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    uses: ./.github/workflows/gatekeeper-validate.yml
+    with:
+      apps-path: fixtures/gatekeeper/apps
+      policy-repo: ""
+      policy-path: fixtures/gatekeeper/policies
+      deny-only: true

--- a/.github/workflows/gatekeeper-validate.yml
+++ b/.github/workflows/gatekeeper-validate.yml
@@ -1,0 +1,152 @@
+# PR / reusable: discover app overlays, expand pod templates, gator test against a policy tree.
+name: Gatekeeper validate
+
+on:
+  workflow_call:
+    inputs:
+      apps-path:
+        description: Root under the caller repo to discover overlays
+        type: string
+        required: false
+        default: "apps"
+      policy-repo:
+        description: Optional GitHub repo (owner/name) with policies. Empty = policies in the caller checkout.
+        type: string
+        required: false
+        default: ""
+      policy-ref:
+        description: Git ref for policy-repo
+        type: string
+        required: false
+        default: "main"
+      policy-checkout-path:
+        description: Directory for the policy checkout when policy-repo is set
+        type: string
+        required: false
+        default: "policy-src"
+      policy-path:
+        description: >
+          Path to the policy Kustomize root (or YAML directory), relative to the policy
+          workspace. Optional {cluster} is replaced with the app overlay cluster segment.
+        type: string
+        required: false
+        default: "policies"
+      policy-path-fallback:
+        description: >
+          If the resolved policy-path does not exist, try this path (also may contain {cluster}).
+          Empty disables fallback.
+        type: string
+        required: false
+        default: ""
+      deny-only:
+        description: Pass --deny-only to gator test (ignore dryrun constraints)
+        type: boolean
+        required: false
+        default: true
+      skip-overlay-name-suffix:
+        description: Skip overlay cluster dirs ending with this suffix (e.g. .old)
+        type: string
+        required: false
+        default: ".old"
+      gator-version:
+        type: string
+        required: false
+        default: "3.22.0"
+      gator-sha256:
+        type: string
+        required: false
+        default: "45ba8c54a22261473bddf6f4f18b154058d45b0c64f3e7a67b2fa781f0791800"
+      kustomize-version:
+        type: string
+        required: false
+        default: "5.8.1"
+      kustomize-sha256:
+        type: string
+        required: false
+        default: "029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d"
+      pyyaml-version:
+        type: string
+        required: false
+        default: "6.0.2"
+    secrets:
+      POLICY_REPO_TOKEN:
+        description: Token with read access to a private policy-repo. Unused when policy-repo is empty or public.
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  gator-test:
+    name: gator test (manifests vs policies)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Require token when cloning private policy-repo
+        if: inputs.policy-repo != ''
+        env:
+          POLICY_REPO_TOKEN: ${{ secrets.POLICY_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Public repos work with the default GITHUB_TOKEN; only fail when an explicit
+          # private token is required and missing after a clone attempt below.
+          echo "policy-repo=${{ inputs.policy-repo }} ref=${{ inputs.policy-ref }}"
+
+      - name: Checkout policy repo
+        if: inputs.policy-repo != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.policy-repo }}
+          ref: ${{ inputs.policy-ref }}
+          path: ${{ inputs.policy-checkout-path }}
+          token: ${{ secrets.POLICY_REPO_TOKEN || github.token }}
+
+      - name: Checkout actionsforge scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: actionsforge/actions
+          # Align scripts with the called workflow revision when available.
+          ref: ${{ github.workflow_sha || github.sha }}
+          path: _gatekeeper_action
+          sparse-checkout: |
+            scripts/gatekeeper
+          sparse-checkout-cone-mode: false
+
+      - name: Install gator + kustomize
+        env:
+          GATOR_VERSION: ${{ inputs.gator-version }}
+          GATOR_LINUX_AMD64_SHA256: ${{ inputs.gator-sha256 }}
+          KUSTOMIZE_VERSION: ${{ inputs.kustomize-version }}
+          KUSTOMIZE_LINUX_AMD64_SHA256: ${{ inputs.kustomize-sha256 }}
+          PYYAML_VERSION: ${{ inputs.pyyaml-version }}
+        run: |
+          set -euo pipefail
+          chmod +x _gatekeeper_action/scripts/gatekeeper/install-tools.sh
+          _gatekeeper_action/scripts/gatekeeper/install-tools.sh /usr/local/bin
+
+      - name: Validate overlays
+        env:
+          APPS_PATH: ${{ inputs.apps-path }}
+          POLICY_REPO: ${{ inputs.policy-repo }}
+          POLICY_CHECKOUT_PATH: ${{ inputs.policy-checkout-path }}
+          POLICY_PATH: ${{ inputs.policy-path }}
+          POLICY_PATH_FALLBACK: ${{ inputs.policy-path-fallback }}
+          DENY_ONLY: ${{ inputs.deny-only }}
+          SKIP_OVERLAY_NAME_SUFFIX: ${{ inputs.skip-overlay-name-suffix }}
+          EXPAND_PODS_PY: _gatekeeper_action/scripts/gatekeeper/expand-pods.py
+        run: |
+          set -euo pipefail
+          chmod +x _gatekeeper_action/scripts/gatekeeper/test-overlays.sh
+          if [[ -n "${POLICY_REPO}" ]]; then
+            export POLICY_ROOT="${POLICY_CHECKOUT_PATH}"
+          else
+            export POLICY_ROOT="."
+          fi
+          if [[ "${DENY_ONLY}" == "true" || "${DENY_ONLY}" == "True" ]]; then
+            export DENY_ONLY=true
+          else
+            export DENY_ONLY=false
+          fi
+          _gatekeeper_action/scripts/gatekeeper/test-overlays.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,12 @@ Workflows whose filenames start with `_` are internal callers for this repo and 
 | [`yaml-lint`](./workflows/yaml-lint.md) | Lint YAML with yamllint |
 | [`validate-devschema`](./workflows/validate-devschema.md) | Validate JSON (e.g. devcontainer) against a schema |
 
+## Kubernetes / policy
+
+| Workflow | Summary |
+| --- | --- |
+| [`gatekeeper-validate`](./workflows/gatekeeper-validate.md) | `gator test` app overlays against a Gatekeeper policy Git tree |
+
 ## CI / language
 
 | Workflow | Summary |

--- a/docs/workflows/gatekeeper-validate.md
+++ b/docs/workflows/gatekeeper-validate.md
@@ -1,0 +1,88 @@
+# `gatekeeper-validate`
+
+Discover app Kustomize overlays, expand CronJob/Deployment/Job pod templates, and run `gator test` against a Gatekeeper policy tree.
+
+## Call
+
+`actionsforge/actions/.github/workflows/gatekeeper-validate.yml@main`
+
+## Example (public k8sforge policies)
+
+```yaml
+name: Gatekeeper validate
+on:
+  pull_request:
+    paths:
+      - "apps/**"
+      - ".github/workflows/gatekeeper-validate.yml"
+permissions:
+  contents: read
+jobs:
+  gator-test:
+    uses: actionsforge/actions/.github/workflows/gatekeeper-validate.yml@main
+    with:
+      apps-path: apps
+      policy-repo: k8sforge/gatekeeper-policies
+      policy-ref: main
+      policy-path: policies/enforce
+```
+
+Use `policies/enforce` when `deny-only` is true (default). Dryrun-only packs are ignored by `--deny-only`.
+
+## Example (policies in the caller repo)
+
+```yaml
+jobs:
+  gator-test:
+    uses: actionsforge/actions/.github/workflows/gatekeeper-validate.yml@main
+    with:
+      apps-path: apps
+      policy-path: policies/base
+```
+
+## Example (private policy repo)
+
+```yaml
+jobs:
+  gator-test:
+    uses: actionsforge/actions/.github/workflows/gatekeeper-validate.yml@main
+    with:
+      policy-repo: my-org/private-policies
+      policy-ref: main
+      policy-path: policies/overlays/{cluster}
+      policy-path-fallback: policies/base
+    secrets:
+      POLICY_REPO_TOKEN: ${{ secrets.POLICY_REPO_TOKEN }}
+```
+
+Pass secrets explicitly across organizations (do not rely on `secrets: inherit`).
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `apps-path` | string | no | `apps` | Root to discover overlays |
+| `policy-repo` | string | no | `""` | Optional `owner/name` GitHub repo with policies |
+| `policy-ref` | string | no | `main` | Git ref for `policy-repo` |
+| `policy-checkout-path` | string | no | `policy-src` | Checkout directory for `policy-repo` |
+| `policy-path` | string | no | `policies` | Policy path relative to policy workspace; optional `{cluster}` |
+| `policy-path-fallback` | string | no | `""` | Fallback path if primary missing |
+| `deny-only` | boolean | no | `true` | Pass `--deny-only` to gator |
+| `skip-overlay-name-suffix` | string | no | `.old` | Skip cluster dirs with this suffix |
+| `gator-version` | string | no | `3.22.0` | gator release |
+| `gator-sha256` | string | no | (pinned) | linux-amd64 tarball SHA-256 |
+| `kustomize-version` | string | no | `5.8.1` | kustomize release |
+| `kustomize-sha256` | string | no | (pinned) | linux-amd64 tarball SHA-256 |
+| `pyyaml-version` | string | no | `6.0.2` | PyYAML pin for expand-pods |
+
+## Secrets
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `POLICY_REPO_TOKEN` | no | Read token for a private `policy-repo` |
+
+## Notes
+
+- This workflow runs **`gator test`** on app manifests. It does not install policies on a cluster and is not **`gator verify`** for Gatekeeper test suites.
+- Overlay discovery matches `*/overlays/*/kustomization.yaml` and `*/overlays/*/manifests/kustomization.yaml` (excludes `vendored/`).
+- Community alternative: [open-policy-agent/gatekeeper-library](https://github.com/open-policy-agent/gatekeeper-library) (templates under `library/`; you usually still need Constraints).

--- a/fixtures/gatekeeper/apps/sample/overlays/ci/manifests/cronjob.yaml
+++ b/fixtures/gatekeeper/apps/sample/overlays/ci/manifests/cronjob.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sample
+  labels:
+    name: sample
+    owner: devops
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sample
+  namespace: sample
+  labels:
+    app.kubernetes.io/name: sample
+    owner: devops
+spec:
+  schedule: "0 0 * * *"
+  timeZone: Pacific/Auckland
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: sample
+            owner: devops
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: pause
+              image: public.ecr.aws/docker/library/busybox:1.36
+              command: ["true"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi

--- a/fixtures/gatekeeper/apps/sample/overlays/ci/manifests/kustomization.yaml
+++ b/fixtures/gatekeeper/apps/sample/overlays/ci/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cronjob.yaml

--- a/fixtures/gatekeeper/policies/constraint-requiredlabels.yaml
+++ b/fixtures/gatekeeper/policies/constraint-requiredlabels.yaml
@@ -1,0 +1,15 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: namespaces-must-have-owner
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  parameters:
+    message: "All namespaces must have an owner label"
+    labels:
+      - key: owner
+        allowedRegex: ".+"

--- a/fixtures/gatekeeper/policies/kustomization.yaml
+++ b/fixtures/gatekeeper/policies/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - template-requiredlabels.yaml
+  - constraint-requiredlabels.yaml

--- a/fixtures/gatekeeper/policies/template-requiredlabels.yaml
+++ b/fixtures/gatekeeper/policies/template-requiredlabels.yaml
@@ -1,0 +1,35 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredlabels
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredLabels
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            labels:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  allowedRegex:
+                    type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredlabels
+        violation[{"msg": msg}] {
+          provided := {label | input.review.object.metadata.labels[label]}
+          required := {label | label := input.parameters.labels[_].key}
+          missing := required - provided
+          count(missing) > 0
+          msg := sprintf("you must provide labels: %v", [missing])
+        }

--- a/scripts/gatekeeper/expand-pods.py
+++ b/scripts/gatekeeper/expand-pods.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Append synthetic Pod manifests from Deployment/CronJob/Job pod templates for gator test.
+
+Gatekeeper constraints that match kind Pod (e.g. allowPrivilegeEscalation) are not
+evaluated against CronJob/Deployment YAML alone. CI and local hooks use this helper.
+"""
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import yaml
+
+
+def _namespace_for(
+    owner: dict[str, Any],
+    template: dict[str, Any],
+    default_ns: str,
+) -> str:
+    """Resolve namespace for a synthetic Pod.
+
+    Kustomize overlays often omit metadata.namespace (Argo sets destination.namespace
+    at sync). Falling back to \"default\" false-fails disallow-default-namespace.
+    """
+    meta = template.get("metadata") or {}
+    labels = meta.get("labels") or {}
+    owner_labels = (owner.get("metadata") or {}).get("labels") or {}
+    return (
+        owner.get("metadata", {}).get("namespace")
+        or meta.get("namespace")
+        or labels.get("name")
+        or owner_labels.get("name")
+        or labels.get("app.kubernetes.io/part-of")
+        or owner_labels.get("app.kubernetes.io/part-of")
+        or labels.get("app.kubernetes.io/name")
+        or owner_labels.get("app.kubernetes.io/name")
+        or default_ns
+    )
+
+
+def _pod_from_template(
+    owner: dict[str, Any],
+    template: dict[str, Any],
+    suffix: str,
+    default_ns: str,
+) -> dict[str, Any]:
+    meta = template.get("metadata") or {}
+    labels = meta.get("labels") or {}
+    name = owner.get("metadata", {}).get("name", "workload")
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": f"{name}-{suffix}",
+            "namespace": _namespace_for(owner, template, default_ns),
+            "labels": labels,
+        },
+        "spec": template["spec"],
+    }
+
+
+def expand(manifests: str) -> str:
+    docs = list(yaml.safe_load_all(manifests))
+    ns_names = [
+        d["metadata"]["name"]
+        for d in docs
+        if d and d.get("kind") == "Namespace" and d.get("metadata", {}).get("name")
+    ]
+    default_ns = ns_names[0] if ns_names else "default"
+
+    out: list[dict[str, Any]] = []
+    for doc in docs:
+        if not doc:
+            continue
+        out.append(doc)
+        kind = doc.get("kind")
+        template = None
+        suffix = "pod"
+        if kind == "CronJob":
+            template = doc["spec"]["jobTemplate"]["spec"]["template"]
+            suffix = "job-pod"
+        elif kind == "Deployment":
+            template = doc["spec"]["template"]
+            suffix = "deploy-pod"
+        elif kind == "Job":
+            template = doc["spec"]["template"]
+            suffix = "job-pod"
+        if template is not None:
+            out.append(_pod_from_template(doc, template, suffix, default_ns))
+    # Must emit multi-doc YAML with --- separators. Concatenating dumps without
+    # --- collapses into one document (last root keys win), so gator never sees
+    # the synthetic Pods and falsely reports PASS.
+    chunks: list[str] = []
+    for d in out:
+        chunks.append("---\n")
+        chunks.append(yaml.dump(d, sort_keys=False))
+    return "".join(chunks)
+
+
+def main() -> None:
+    print(expand(sys.stdin.read()), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gatekeeper/install-tools.sh
+++ b/scripts/gatekeeper/install-tools.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Install pinned gator + kustomize and PyYAML for Gatekeeper CI.
+# Version/SHA pins are the single source of truth for this reusable workflow.
+set -euo pipefail
+
+GATOR_VERSION="${GATOR_VERSION:-3.22.0}"
+GATOR_LINUX_AMD64_SHA256="${GATOR_LINUX_AMD64_SHA256:-45ba8c54a22261473bddf6f4f18b154058d45b0c64f3e7a67b2fa781f0791800}"
+KUSTOMIZE_VERSION="${KUSTOMIZE_VERSION:-5.8.1}"
+KUSTOMIZE_LINUX_AMD64_SHA256="${KUSTOMIZE_LINUX_AMD64_SHA256:-029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d}"
+PYYAML_VERSION="${PYYAML_VERSION:-6.0.2}"
+DEST_DIR="${1:-/usr/local/bin}"
+
+gator_url="https://github.com/open-policy-agent/gatekeeper/releases/download/v${GATOR_VERSION}/gator-v${GATOR_VERSION}-linux-amd64.tar.gz"
+gator_tmp="/tmp/gator-v${GATOR_VERSION}-linux-amd64.tar.gz"
+curl -fsSL -o "$gator_tmp" "$gator_url"
+echo "${GATOR_LINUX_AMD64_SHA256}  ${gator_tmp}" | sha256sum -c -
+sudo tar xzf "$gator_tmp" -C "${DEST_DIR}"
+rm -f "$gator_tmp"
+
+kus_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+kus_tmp="/tmp/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+curl -fsSL -o "$kus_tmp" "$kus_url"
+echo "${KUSTOMIZE_LINUX_AMD64_SHA256}  ${kus_tmp}" | sha256sum -c -
+sudo tar xzf "$kus_tmp" -C "${DEST_DIR}"
+rm -f "$kus_tmp"
+
+python3 -m pip install --user "pyyaml==${PYYAML_VERSION}"
+
+gator version | grep GitVersion
+kustomize version

--- a/scripts/gatekeeper/test-overlays.sh
+++ b/scripts/gatekeeper/test-overlays.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Discover app overlays and run gator test against a policy kustomize root.
+#
+# Env:
+#   APPS_PATH                 (default: apps)
+#   POLICY_ROOT               workspace that contains POLICY_PATH (caller or policy checkout)
+#   POLICY_PATH               relative path; may contain {cluster}
+#   POLICY_PATH_FALLBACK      optional fallback path (may contain {cluster})
+#   DENY_ONLY                 true|false (default true)
+#   SKIP_OVERLAY_NAME_SUFFIX  skip cluster dirs ending with this (default .old)
+#   EXPAND_PODS_PY            path to expand-pods.py
+#   GITHUB_STEP_SUMMARY       optional
+set -euo pipefail
+
+APPS_PATH="${APPS_PATH:-apps}"
+POLICY_ROOT="${POLICY_ROOT:?POLICY_ROOT is required}"
+POLICY_PATH="${POLICY_PATH:-policies}"
+POLICY_PATH_FALLBACK="${POLICY_PATH_FALLBACK:-}"
+DENY_ONLY="${DENY_ONLY:-true}"
+SKIP_OVERLAY_NAME_SUFFIX="${SKIP_OVERLAY_NAME_SUFFIX:-.old}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPAND_PODS_PY="${EXPAND_PODS_PY:-$SCRIPT_DIR/expand-pods.py}"
+
+if [[ ! -f "$EXPAND_PODS_PY" ]]; then
+  echo "expand-pods script not found: $EXPAND_PODS_PY" >&2
+  exit 1
+fi
+if ! command -v gator >/dev/null || ! command -v kustomize >/dev/null; then
+  echo "gator and kustomize must be on PATH" >&2
+  exit 1
+fi
+
+resolve_policy_dir() {
+  local cluster="$1"
+  local primary="${POLICY_PATH//\{cluster\}/$cluster}"
+  local fallback="${POLICY_PATH_FALLBACK//\{cluster\}/$cluster}"
+  local candidate="$POLICY_ROOT/$primary"
+  if [[ -d "$candidate" ]]; then
+    echo "$candidate"
+    return 0
+  fi
+  if [[ -n "$POLICY_PATH_FALLBACK" ]]; then
+    candidate="$POLICY_ROOT/$fallback"
+    if [[ -d "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  fi
+  echo "policy path not found for cluster=${cluster:-none}: tried $POLICY_ROOT/$primary" >&2
+  if [[ -n "$POLICY_PATH_FALLBACK" ]]; then
+    echo "  and fallback $POLICY_ROOT/$fallback" >&2
+  fi
+  return 1
+}
+
+build_policies() {
+  local policy_dir="$1"
+  local out="$2"
+  if [[ -f "$policy_dir/kustomization.yaml" || -f "$policy_dir/kustomization.yml" ]]; then
+    kustomize build "$policy_dir" >"$out"
+  else
+    # Concatenate YAML files for non-kustomize dirs
+    : >"$out"
+    local f
+    for f in "$policy_dir"/*.yaml "$policy_dir"/*.yml; do
+      [[ -f "$f" ]] || continue
+      printf '\n---\n' >>"$out"
+      cat "$f" >>"$out"
+    done
+  fi
+}
+
+mapfile -t overlays < <(find "$APPS_PATH" -type f \( \
+  \( -path '*/overlays/*/kustomization.yaml' ! -path '*/vendored/*' \) -o \
+  \( -path '*/overlays/*/manifests/kustomization.yaml' ! -path '*/vendored/*' \) \
+\) | sort -u)
+
+if [[ "${#overlays[@]}" -eq 0 ]]; then
+  echo "No overlays found under ${APPS_PATH}/." >&2
+  exit 1
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+declare -A policy_cache=()
+failed=0
+pass=0
+summary=()
+
+gator_args=(test)
+if [[ "$DENY_ONLY" == "true" ]]; then
+  gator_args+=(--deny-only)
+fi
+
+for k in "${overlays[@]}"; do
+  d="$(dirname "$k")"
+  cluster="$(sed -n 's|.*/overlays/\([^/]*\).*|\1|p' <<<"$d" | head -1)"
+  if [[ -n "$SKIP_OVERLAY_NAME_SUFFIX" && "$cluster" == *"$SKIP_OVERLAY_NAME_SUFFIX" ]]; then
+    echo "SKIP $d (suffix $SKIP_OVERLAY_NAME_SUFFIX)"
+    continue
+  fi
+
+  if ! policy_dir="$(resolve_policy_dir "$cluster")"; then
+    failed=1
+    summary+=("FAIL $d (policy path missing)")
+    continue
+  fi
+
+  cache_key="$policy_dir"
+  policy_file="$work/policies-$(echo "$cache_key" | sha256sum | awk '{print $1}').yaml"
+  if [[ -z "${policy_cache[$cache_key]+x}" ]]; then
+    build_policies "$policy_dir" "$policy_file"
+    policy_cache[$cache_key]=1
+  fi
+
+  manifests_file="$work/manifests-$(echo "$d" | sha256sum | awk '{print $1}').yaml"
+  kustomize build "$d" | python3 "$EXPAND_PODS_PY" >"$manifests_file"
+
+  if output=$(gator "${gator_args[@]}" -f "$policy_file" -f "$manifests_file" </dev/null 2>&1); then
+    echo "PASS $d (policies: $policy_dir)"
+    summary+=("PASS $d")
+    pass=$((pass + 1))
+  else
+    echo "FAIL $d (policies: $policy_dir)"
+    echo "$output"
+    summary+=("FAIL $d")
+    failed=1
+  fi
+done
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Gatekeeper validate"
+    echo ""
+    echo "| Result | Overlay |"
+    echo "| --- | --- |"
+    for line in "${summary[@]}"; do
+      status="${line%% *}"
+      rest="${line#* }"
+      echo "| $status | \`$rest\` |"
+    done
+  } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "One or more overlays have policy violations." >&2
+  exit 1
+fi
+if [[ "$pass" -eq 0 ]]; then
+  echo "No overlays were tested (all skipped?)." >&2
+  exit 1
+fi
+echo "All overlays passed ($pass roots)."


### PR DESCRIPTION
## Summary
- Add `gatekeeper-validate` reusable workflow (`workflow_call`)
- Scripts: install-tools, test-overlays, expand-pods
- Fixture smoke via `_gatekeeper-validate.yml`
- Docs + docs/README index

Closes #150

## Test plan
- [x] Local `test-overlays.sh` against fixtures
- [ ] PR `_gatekeeper-validate` smoke
- [ ] markdown-lint / commitmsg-conform