### PR TITLE
fix: checkout gatekeeper scripts at a fetchable ref

### DIFF
--- a/.github/workflows/gatekeeper-validate.yml
+++ b/.github/workflows/gatekeeper-validate.yml
@@ -48,6 +48,11 @@ on:
         type: string
         required: false
         default: ".old"
+      actionsforge-ref:
+        description: Git ref of actionsforge/actions used for scripts/gatekeeper (keep aligned with the workflow pin)
+        type: string
+        required: false
+        default: "main"
       gator-version:
         type: string
         required: false
@@ -107,8 +112,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: actionsforge/actions
-          # Align scripts with the called workflow revision when available.
-          ref: ${{ github.workflow_sha || github.sha }}
+          ref: ${{ inputs.actionsforge-ref }}
           path: _gatekeeper_action
           sparse-checkout: |
             scripts/gatekeeper

--- a/docs/workflows/gatekeeper-validate.md
+++ b/docs/workflows/gatekeeper-validate.md
@@ -74,6 +74,7 @@ Pass secrets explicitly across organizations (do not rely on `secrets: inherit`)
 | `kustomize-version` | string | no | `5.8.1` | kustomize release |
 | `kustomize-sha256` | string | no | (pinned) | linux-amd64 tarball SHA-256 |
 | `pyyaml-version` | string | no | `6.0.2` | PyYAML pin for expand-pods |
+| `actionsforge-ref` | string | no | `main` | Ref of `actionsforge/actions` for `scripts/gatekeeper` (pin to the same commit as the workflow `uses:` when needed) |
 
 ## Secrets
 


### PR DESCRIPTION
## Summary
- Replace `github.workflow_sha` scripts checkout with `actionsforge-ref` (default `main`)
- Document the input

Closes #152

## Test plan
- [ ] `_gatekeeper-validate` smoke
- [ ] Re-run kube-devops-apps Gatekeeper job after merge