### PR TITLE
fix: run PR scripts in internal gatekeeper smoke

### DIFF
--- a/.github/workflows/_gatekeeper-validate.yml
+++ b/.github/workflows/_gatekeeper-validate.yml
@@ -20,3 +20,7 @@ jobs:
       policy-repo: ""
       policy-path: fixtures/gatekeeper/policies
       deny-only: true
+      # scripts/gatekeeper is cloned by the reusable, and its default ref (main) would
+      # hide this PR's script changes. The merge ref is what actions/checkout already
+      # resolves for the caller, and it is fetchable here even for fork PRs.
+      actionsforge-ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/docs/workflows/gatekeeper-validate.md
+++ b/docs/workflows/gatekeeper-validate.md
@@ -85,5 +85,6 @@ Pass secrets explicitly across organizations (do not rely on `secrets: inherit`)
 ## Notes
 
 - This workflow runs **`gator test`** on app manifests. It does not install policies on a cluster and is not **`gator verify`** for Gatekeeper test suites.
+- **`actionsforge-ref`** decides which copy of `scripts/gatekeeper` runs, independently of the ref you pin in `uses:`. Leaving it at `main` while testing a change to those scripts silently runs the `main` versions instead. To exercise a pull request's scripts, pass `refs/pull/<n>/merge`.
 - Overlay discovery matches `*/overlays/*/kustomization.yaml` and `*/overlays/*/manifests/kustomization.yaml` (excludes `vendored/`).
 - Community alternative: [open-policy-agent/gatekeeper-library](https://github.com/open-policy-agent/gatekeeper-library) (templates under `library/`; you usually still need Constraints).


### PR DESCRIPTION
Closes #156

`_gatekeeper-validate.yml` triggers on `scripts/gatekeeper/**`, but the reusable clones those scripts at `actionsforge-ref`, which defaults to `main` — so a PR editing them was validated against the versions already merged.

The smoke now passes `refs/pull/<n>/merge`. That is the same ref `actions/checkout` resolves for the caller checkout, so scripts, fixtures, and workflow all come from one commit, and unlike a fork head SHA it is fetchable from this repo.

## Verification

Demonstrated on this PR with a temporary canary commit that put `exit 1` at the top of `test-overlays.sh` (since dropped):

- canary alone, before the fix -> `smoke / gator test` **passed**, proving the PR script never ran
- canary plus the fix -> `smoke / gator test` **failed**, with `CANARY: this PR's test-overlays.sh is running` in the log and `ref: refs/pull/157/merge` in the checkout step

Only the fix remains on the branch, so the smoke is green again.