### PR TITLE
fix: expand DaemonSet and StatefulSet pod templates

### DIFF
--- a/.github/workflows/_gatekeeper-validate.yml
+++ b/.github/workflows/_gatekeeper-validate.yml
@@ -13,6 +13,21 @@ permissions:
   contents: read
 
 jobs:
+  # The fixtures cannot catch an expansion regression on their own: a compliant
+  # workload passes whether or not its Pod was synthesized.
+  expand-pods:
+    name: expand-pods unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user "pyyaml==6.0.2"
+
+      - name: Run tests
+        run: python3 scripts/gatekeeper/expand-pods-test.py
+
   smoke:
     uses: ./.github/workflows/gatekeeper-validate.yml
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/docs/workflows/gatekeeper-validate.md
+++ b/docs/workflows/gatekeeper-validate.md
@@ -1,6 +1,8 @@
 # `gatekeeper-validate`
 
-Discover app Kustomize overlays, expand CronJob/Deployment/Job pod templates, and run `gator test` against a Gatekeeper policy tree.
+Discover app Kustomize overlays, expand Deployment/DaemonSet/StatefulSet/Job/CronJob pod templates, and run `gator test` against a Gatekeeper policy tree.
+
+Constraints that match `kind: Pod` never see a workload's containers unless a Pod is synthesized from its template, so any kind that is not expanded is silently exempt from every pod-security policy. DaemonSet and StatefulSet are included because node-level workloads such as CSI drivers and log shippers are the most likely to need privileged or host access — exactly what those policies exist to catch.
 
 ## Call
 

--- a/scripts/gatekeeper/expand-pods-test.py
+++ b/scripts/gatekeeper/expand-pods-test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Unit tests for expand-pods.py.
+
+The gatekeeper-validate smoke fixtures cannot catch an expansion regression: a
+compliant workload passes whether or not its Pod was synthesized. These tests
+assert the Pod actually appears for every supported kind.
+
+Run: python3 scripts/gatekeeper/expand-pods-test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+import yaml
+
+_SPEC = importlib.util.spec_from_file_location(
+    "expand_pods", pathlib.Path(__file__).with_name("expand-pods.py")
+)
+expand_pods = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(expand_pods)
+
+
+def pods(manifests: str) -> list[dict]:
+    return [
+        d
+        for d in yaml.safe_load_all(expand_pods.expand(manifests))
+        if d and d.get("kind") == "Pod"
+    ]
+
+
+def workload(kind: str, name: str = "wl", namespace: str = "demo") -> str:
+    template = {
+        "metadata": {"labels": {"app": name}},
+        "spec": {"containers": [{"name": "app", "image": "example.com/app:1.0.0"}]},
+    }
+    spec: dict = {}
+    if kind == "CronJob":
+        spec = {"schedule": "* * * * *", "jobTemplate": {"spec": {"template": template}}}
+    else:
+        spec = {"template": template}
+    return yaml.dump(
+        {
+            "apiVersion": "apps/v1",
+            "kind": kind,
+            "metadata": {"name": name, "namespace": namespace},
+            "spec": spec,
+        }
+    )
+
+
+class TestExpand(unittest.TestCase):
+    def test_every_supported_kind_yields_a_pod(self):
+        for kind, suffix in [
+            ("Deployment", "deploy-pod"),
+            ("DaemonSet", "daemonset-pod"),
+            ("StatefulSet", "statefulset-pod"),
+            ("Job", "job-pod"),
+            ("CronJob", "job-pod"),
+        ]:
+            with self.subTest(kind=kind):
+                got = pods(workload(kind))
+                self.assertEqual(len(got), 1, f"{kind} produced no synthetic Pod")
+                self.assertEqual(got[0]["metadata"]["name"], f"wl-{suffix}")
+                self.assertEqual(got[0]["metadata"]["namespace"], "demo")
+                self.assertEqual(
+                    got[0]["spec"]["containers"][0]["name"],
+                    "app",
+                    f"{kind} pod spec not carried over",
+                )
+
+    def test_container_security_context_is_preserved(self):
+        # The whole point is that pod-security constraints see container fields.
+        doc = yaml.safe_load(workload("DaemonSet"))
+        doc["spec"]["template"]["spec"]["containers"][0]["securityContext"] = {
+            "privileged": True
+        }
+        got = pods(yaml.dump(doc))
+        self.assertTrue(got[0]["spec"]["containers"][0]["securityContext"]["privileged"])
+
+    def test_unsupported_kind_is_passed_through_without_a_pod(self):
+        svc = yaml.dump(
+            {"apiVersion": "v1", "kind": "Service", "metadata": {"name": "svc"}}
+        )
+        self.assertEqual(pods(svc), [])
+
+    def test_output_is_multi_doc(self):
+        # Missing --- separators collapse everything into one document and gator
+        # then never sees the synthetic Pods, reporting a false PASS.
+        out = expand_pods.expand(workload("StatefulSet"))
+        self.assertGreaterEqual(len([d for d in yaml.safe_load_all(out) if d]), 2)
+
+    def test_namespace_falls_back_to_namespace_manifest(self):
+        doc = yaml.safe_load(workload("DaemonSet"))
+        del doc["metadata"]["namespace"]
+        manifests = (
+            yaml.dump(
+                {
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
+                    "metadata": {"name": "from-ns-manifest"},
+                }
+            )
+            + "---\n"
+            + yaml.dump(doc)
+        )
+        self.assertEqual(pods(manifests)[0]["metadata"]["namespace"], "from-ns-manifest")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/gatekeeper/expand-pods.py
+++ b/scripts/gatekeeper/expand-pods.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Append synthetic Pod manifests from Deployment/CronJob/Job pod templates for gator test.
+"""Append synthetic Pod manifests from workload pod templates for gator test.
 
 Gatekeeper constraints that match kind Pod (e.g. allowPrivilegeEscalation) are not
 evaluated against CronJob/Deployment YAML alone. CI and local hooks use this helper.
+
+Covers Deployment, DaemonSet, StatefulSet, Job, and CronJob. DaemonSet and
+StatefulSet matter because node-level workloads (CSI drivers, log shippers) are the
+ones most likely to need privileged or host access, so omitting them hides exactly
+the workloads a pod-security policy is meant to catch.
 """
 from __future__ import annotations
 
@@ -85,6 +90,12 @@ def expand(manifests: str) -> str:
         elif kind == "Job":
             template = doc["spec"]["template"]
             suffix = "job-pod"
+        elif kind == "DaemonSet":
+            template = doc["spec"]["template"]
+            suffix = "daemonset-pod"
+        elif kind == "StatefulSet":
+            template = doc["spec"]["template"]
+            suffix = "statefulset-pod"
         if template is not None:
             out.append(_pod_from_template(doc, template, suffix, default_ns))
     # Must emit multi-doc YAML with --- separators. Concatenating dumps without


### PR DESCRIPTION
Closes #158

Constraints that match `kind: Pod` never see a workload's containers unless a Pod is synthesised from its template, so any kind the expander skips is **silently exempt from every pod-security policy**. `DaemonSet` and `StatefulSet` were skipped, which is backwards: node-level workloads such as CSI drivers and log shippers are the most likely to need privileged or host access.

Found in `k8sforge/kube-infra`, where the EBS CSI driver's node DaemonSet runs `privileged: true` and violates seven constraints that CI could not see:

```
Deployment ebs-csi-controller  ebs-plugin  privileged=None   <- expanded, checked
DaemonSet  ebs-csi-node        ebs-plugin  privileged=True   <- never expanded
```

## Testing

The `fixtures/gatekeeper` smoke cannot catch an expansion regression on its own, because a compliant workload passes whether or not its Pod was synthesised. So this adds `scripts/gatekeeper/expand-pods-test.py` (stdlib `unittest`, PyYAML only) covering:

- every supported kind yields exactly one Pod with the right name suffix, namespace, and container spec
- container `securityContext` survives expansion, which is the entire point
- unsupported kinds pass through without generating a Pod
- output stays multi-doc, since missing `---` separators collapse the stream and produce a false PASS
- namespace falls back to a `Namespace` manifest when the workload omits it

`_gatekeeper-validate.yml` gains a job that runs them. I verified the tests actually catch the bug by deleting the `DaemonSet` branch in a throwaway copy:

```
AssertionError: 0 != 1 : DaemonSet produced no synthetic Pod
FAILED (failures=1, errors=2)
```

## Blast radius for consumers

Checked before landing: `kube-devops-apps`, `kube-platform-apps`, and `kube-collection-apps` contain **zero** DaemonSets or StatefulSets, so this is a no-op for them. `kube-infra` has the only affected workload and is not yet on this reusable, so nothing goes red on merge.