### PR TITLE
fix: tolerate already-enabled auto-merge in dependabot-auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -128,10 +128,27 @@ jobs:
             squash) method_flag="--squash" ;;
           esac
 
+          # Treat "already enabled / merge already in progress / clean status"
+          # as success. The caller fires on multiple events (pull_request +
+          # check_suite), so a later run often finds auto-merge already enabled.
+          benign="already in progress|already enabled|clean status|not mergeable: the merge commit cannot be cleanly created"
+
           if [ "$USE_AUTO" = "true" ]; then
-            gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --auto $method_flag
-            echo "Enabled auto-merge on #$PR"
+            if out=$(gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --auto $method_flag 2>&1); then
+              echo "Enabled auto-merge on #$PR"
+            elif echo "$out" | grep -qiE "$benign"; then
+              echo "Auto-merge already enabled / in progress on #$PR; nothing to do"
+            else
+              echo "$out" >&2
+              exit 1
+            fi
           else
-            gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" $method_flag
-            echo "Merged #$PR"
+            if out=$(gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" $method_flag 2>&1); then
+              echo "Merged #$PR"
+            elif echo "$out" | grep -qiE "$benign"; then
+              echo "Merge already in progress on #$PR; nothing to do"
+            else
+              echo "$out" >&2
+              exit 1
+            fi
           fi


### PR DESCRIPTION
## What

Make the `dependabot-auto-merge` reusable idempotent: capture `gh pr merge` output and treat benign states (`Merge already in progress`, `already enabled`, `clean status`) as success for both the `--auto` and immediate-merge paths. Only genuine errors now fail the job.

## Why

Callers trigger this workflow on multiple events (`pull_request` opened/synchronize/reopened **and** `check_suite completed`). A later run calls `gh pr merge "$PR" --auto` when GitHub auto-merge is already enabled, so `gh` returns:

```
GraphQL: Merge already in progress (mergePullRequest)
```

and exits 1. That marks the `auto-merge` check red and blocks the exact Dependabot PRs it is supposed to merge.

Observed on all 5 open PRs in [platformfuzz/images](https://github.com/platformfuzz/images/pulls) (e.g. [run 31270980816](https://github.com/platformfuzz/images/actions/runs/31270980816)); every other check (build-apko, build-docker, markdown-lint, commitmsg-conform, prepare) passes.

## Effect

No input/interface changes. Consumers pin `@main`, so once merged the fix applies everywhere and the stuck Dependabot PRs can complete their auto-merge.