### PR TITLE
feat: default zensical-pages-deploy python to 3.14

### DIFF
--- a/.github/workflows/zensical-pages-deploy.yml
+++ b/.github/workflows/zensical-pages-deploy.yml
@@ -7,7 +7,7 @@ on:
         description: Python version for the Zensical build
         type: string
         required: false
-        default: "3.13"
+        default: "3.14"
       working-directory:
         description: Directory that contains zensical.toml (and usually requirements.txt)
         type: string

--- a/docs/workflows/zensical-pages-deploy.md
+++ b/docs/workflows/zensical-pages-deploy.md
@@ -14,7 +14,7 @@ jobs:
   pages:
     uses: actionsforge/actions/.github/workflows/zensical-pages-deploy.yml@main
     with:
-      python-version: "3.13"
+      python-version: "3.14"
 ```
 
 For a site whose `zensical.toml` is not at the repository root:
@@ -32,7 +32,7 @@ jobs:
 
 | Name | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `python-version` | `string` | no | `3.13` | Python version for the Zensical build |
+| `python-version` | `string` | no | `3.14` | Python version for the Zensical build |
 | `working-directory` | `string` | no | `.` | Directory that contains `zensical.toml` |
 | `requirements-file` | `string` | no | `requirements.txt` | Pip requirements file relative to `working-directory` |
 | `destination` | `string` | no | `site` | Zensical output directory (Pages artifact path) |


### PR DESCRIPTION
## Summary
- Default `python-version` on `zensical-pages-deploy` is `3.14`
- Docs example and inputs table match

Closes #163

## Test plan
- [ ] markdown-lint / commitmsg-conform