### PR TITLE
fix: grant workflows write on dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,8 @@ name: dependabot-auto-merge
 # Enable GitHub auto-merge for Dependabot PRs without approving them.
 # Org policy may block Actions from creating PR approvals; gh --auto does not need that.
 # Callers should trigger on pull_request (+ optional check_suite) and pass secrets: inherit.
+# Callers that expect Action bumps to auto-merge must also grant workflows: write
+# (GITHUB_TOKEN cannot update .github/workflows/* without it).
 #
 # Note: `target` is a SemVer ceiling (major|minor|patch|any), not a branch name.
 
@@ -44,6 +46,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
+  workflows: write
 
 jobs:
   auto-merge:

--- a/docs/workflows/dependabot-auto-merge.md
+++ b/docs/workflows/dependabot-auto-merge.md
@@ -9,14 +9,20 @@ Enable GitHub auto-merge for Dependabot PRs.
 ## Example
 
 ```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  workflows: write # required when Dependabot edits .github/workflows/*
+
 jobs:
   call:
     uses: actionsforge/actions/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit
     with:
       target: any
       merge-method: squash
       use-github-auto-merge: true
-      skip-verification: false
 ```
 
 ## Inputs
@@ -33,5 +39,5 @@ jobs:
 ## Notes
 
 - Enable **Allow auto-merge** on the repo and configure branch protection/rulesets for `gh pr merge --auto`.
-- PRs that change workflow files may fail to merge with `GITHUB_TOKEN` (needs `workflows` permission).
+- Callers must grant `workflows: write` (in addition to the reusable) so Dependabot PRs that edit `.github/workflows/*` can merge with `GITHUB_TOKEN`.
 


### PR DESCRIPTION
## Summary
- Add `workflows: write` to `dependabot-auto-merge.yml`
- Document that callers must grant the same for Action-file bumps

Closes #165

## Test plan
- [ ] Commitmsg / markdown checks pass
- [ ] A Dependabot PR that edits a workflow can auto-merge when the caller also grants `workflows: write`