### PR TITLE
fix: remove invalid workflows permission from dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,8 +3,9 @@ name: dependabot-auto-merge
 # Enable GitHub auto-merge for Dependabot PRs without approving them.
 # Org policy may block Actions from creating PR approvals; gh --auto does not need that.
 # Callers should trigger on pull_request (+ optional check_suite) and pass secrets: inherit.
-# Callers that expect Action bumps to auto-merge must also grant workflows: write
-# (GITHUB_TOKEN cannot update .github/workflows/* without it).
+# Do not add `workflows: write` to permissions — GitHub rejects it as an invalid scope.
+# Dependabot PRs that edit `.github/workflows/*` may need manual merge unless repo
+# workflow permissions allow GITHUB_TOKEN write (Settings → Actions → Workflow permissions).
 #
 # Note: `target` is a SemVer ceiling (major|minor|patch|any), not a branch name.
 
@@ -46,7 +47,6 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
-  workflows: write
 
 jobs:
   auto-merge:

--- a/docs/workflows/dependabot-auto-merge.md
+++ b/docs/workflows/dependabot-auto-merge.md
@@ -13,7 +13,6 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
-  workflows: write # required when Dependabot edits .github/workflows/*
 
 jobs:
   call:
@@ -39,5 +38,5 @@ jobs:
 ## Notes
 
 - Enable **Allow auto-merge** on the repo and configure branch protection/rulesets for `gh pr merge --auto`.
-- Callers must grant `workflows: write` (in addition to the reusable) so Dependabot PRs that edit `.github/workflows/*` can merge with `GITHUB_TOKEN`.
-
+- Do **not** add `workflows: write` to caller or reusable `permissions` — GitHub rejects it (`Unexpected value 'workflows'`).
+- Dependabot PRs that edit `.github/workflows/*` may still fail auto-merge at merge time; set repo **Workflow permissions** to read/write or merge those PRs manually.


### PR DESCRIPTION
## Summary
- Remove invalid `workflows: write` from `dependabot-auto-merge.yml`
- Correct docs: GitHub rejects `workflows` as a permissions scope (`Unexpected value 'workflows'`)

Closes #167

## Test plan
- [ ] Workflow file validates
- [ ] Callers referencing `@main` can parse auto-merge again